### PR TITLE
Add support for DukeNano3D's .grp and .grp.zip files

### DIFF
--- a/duke3d-go/components/audiolib/_multivc.h
+++ b/duke3d-go/components/audiolib/_multivc.h
@@ -137,6 +137,10 @@ typedef struct VoiceNode
 
    unsigned long callbackval;
 
+   void         *rawdataptr;
+   unsigned long rawdatasiz;
+   int           ownsRawData;
+
    } VoiceNode;
 
 typedef struct

--- a/duke3d-go/components/audiolib/multivoc.c
+++ b/duke3d-go/components/audiolib/multivoc.c
@@ -159,6 +159,240 @@ int MV_ErrorCode = MV_Ok;
 #define MV_SetErrorCode( status ) \
    MV_ErrorCode   = ( status );
 
+static uint16_t MV_ReadLE16( const uint8_t *p )
+{
+   return (uint16_t)( p[0] | ( p[1] << 8 ) );
+}
+
+static uint32_t MV_ReadLE32( const uint8_t *p )
+{
+   return (uint32_t)( p[0] | ( p[1] << 8 ) | ( p[2] << 16 ) | ( p[3] << 24 ) );
+}
+
+static int MV_DecodeIMAADPCMNibble( int predictor, int *index, int nibble )
+{
+   static const int indexTable[ 16 ] =
+   {
+      -1, -1, -1, -1, 2, 4, 6, 8,
+      -1, -1, -1, -1, 2, 4, 6, 8,
+   };
+
+   static const int stepTable[ 89 ] =
+   {
+         7,     8,     9,    10,    11,    12,    13,    14,
+        16,    17,    19,    21,    23,    25,    28,    31,
+        34,    37,    41,    45,    50,    55,    60,    66,
+        73,    80,    88,    97,   107,   118,   130,   143,
+       157,   173,   190,   209,   230,   253,   279,   307,
+       337,   371,   408,   449,   494,   544,   598,   658,
+       724,   796,   876,   963,  1060,  1166,  1282,  1411,
+      1552,  1707,  1878,  2066,  2272,  2499,  2749,  3024,
+      3327,  3660,  4026,  4428,  4871,  5358,  5894,  6484,
+      7132,  7845,  8630,  9493, 10442, 11487, 12635, 13899,
+     15289, 16818, 18500, 20350, 22385, 24623, 27086, 29794,
+     32767,
+   };
+
+   int step = stepTable[ *index ];
+   int delta = step >> 3;
+
+   if ( nibble & 1 ) delta += step >> 2;
+   if ( nibble & 2 ) delta += step >> 1;
+   if ( nibble & 4 ) delta += step;
+
+   predictor += ( nibble & 8 ) ? -delta : delta;
+   predictor = max( predictor, -32768 );
+   predictor = min( predictor, 32767 );
+
+   *index += indexTable[ nibble & 15 ];
+   *index = max( *index, 0 );
+   *index = min( *index, 88 );
+
+   return predictor;
+}
+
+static int MV_DecodeWAVIMAADPCM
+   (
+   const uint8_t *dataPtr,
+   uint32_t dataSize,
+   int channels,
+   int blockAlign,
+   int samplesPerBlock,
+   int16_t **decodedOut,
+   uint32_t *decodedSamplesPerChannelOut
+   )
+
+   {
+   uint32_t blocks;
+   uint64_t maxSamples;
+   uint64_t maxBytes;
+   int16_t *decoded;
+   uint32_t offset;
+   uint32_t writeIndex;
+
+   if ( decodedOut == NULL || decodedSamplesPerChannelOut == NULL )
+      {
+      return FALSE;
+      }
+
+   *decodedOut = NULL;
+   *decodedSamplesPerChannelOut = 0;
+
+   if ( ( channels != 1 && channels != 2 ) || blockAlign <= 0 || samplesPerBlock <= 0 || dataSize == 0 )
+      {
+      return FALSE;
+      }
+
+   if ( ( dataSize % (uint32_t)blockAlign ) != 0 )
+      {
+      return FALSE;
+      }
+
+   blocks = dataSize / (uint32_t)blockAlign;
+   if ( blocks == 0 )
+      {
+      return FALSE;
+      }
+
+   maxSamples = (uint64_t)blocks * (uint64_t)samplesPerBlock * (uint64_t)channels;
+   maxBytes = maxSamples * sizeof( int16_t );
+
+   if ( maxBytes == 0 || maxBytes > 0xffffffffu )
+      {
+      return FALSE;
+      }
+
+   if ( USRHOOKS_GetMem( ( void ** )&decoded, (uint32_t)maxBytes ) != USRHOOKS_Ok || decoded == NULL )
+      {
+      return FALSE;
+      }
+
+   offset = 0;
+   writeIndex = 0;
+
+   while ( offset < dataSize )
+      {
+      const uint8_t *block = dataPtr + offset;
+      uint32_t blockSize = (uint32_t)blockAlign;
+      int headerSize = 4 * channels;
+      int predictor[ 2 ] = { 0, 0 };
+      int index[ 2 ] = { 0, 0 };
+      int derivedSamplesPerBlock;
+      int blockSamplesPerChannel;
+      int remaining;
+      const uint8_t *src;
+      const uint8_t *srcEnd;
+
+      if ( blockSize < (uint32_t)headerSize )
+         {
+         USRHOOKS_FreeMem( decoded );
+         return FALSE;
+         }
+
+      for ( int ch = 0; ch < channels; ++ch )
+         {
+         const uint8_t *hdr = block + ( ch * 4 );
+         predictor[ ch ] = (int)(int16_t)MV_ReadLE16( hdr );
+         index[ ch ] = (int)hdr[ 2 ];
+
+         if ( index[ ch ] > 88 )
+            {
+            USRHOOKS_FreeMem( decoded );
+            return FALSE;
+            }
+         }
+
+      derivedSamplesPerBlock = 1 + ( ( (int)blockSize - headerSize ) * 2 ) / channels;
+      if ( derivedSamplesPerBlock <= 0 )
+         {
+         USRHOOKS_FreeMem( decoded );
+         return FALSE;
+         }
+
+      blockSamplesPerChannel = min( samplesPerBlock, derivedSamplesPerBlock );
+      if ( blockSamplesPerChannel <= 0 )
+         {
+         USRHOOKS_FreeMem( decoded );
+         return FALSE;
+         }
+
+      for ( int ch = 0; ch < channels; ++ch )
+         {
+         decoded[ writeIndex++ ] = (int16_t)predictor[ ch ];
+         }
+
+      remaining = blockSamplesPerChannel - 1;
+      src = block + headerSize;
+      srcEnd = block + blockSize;
+
+      if ( channels == 1 )
+         {
+         while ( remaining > 0 )
+            {
+            uint8_t byte;
+
+            if ( src >= srcEnd )
+               {
+               USRHOOKS_FreeMem( decoded );
+               return FALSE;
+               }
+
+            byte = *src++;
+
+            predictor[ 0 ] = MV_DecodeIMAADPCMNibble( predictor[ 0 ], &index[ 0 ], byte & 0x0f );
+            decoded[ writeIndex++ ] = (int16_t)predictor[ 0 ];
+            --remaining;
+            if ( remaining <= 0 )
+               {
+               break;
+               }
+
+            predictor[ 0 ] = MV_DecodeIMAADPCMNibble( predictor[ 0 ], &index[ 0 ], byte >> 4 );
+            decoded[ writeIndex++ ] = (int16_t)predictor[ 0 ];
+            --remaining;
+            }
+         }
+      else
+         {
+         while ( remaining > 0 )
+            {
+            uint8_t chBytes[ 2 ][ 4 ];
+
+            if ( src + 8 > srcEnd )
+               {
+               USRHOOKS_FreeMem( decoded );
+               return FALSE;
+               }
+
+            memcpy( chBytes[ 0 ], src, 4 );
+            memcpy( chBytes[ 1 ], src + 4, 4 );
+            src += 8;
+
+            for ( int i = 0; i < 8 && remaining > 0; ++i )
+               {
+               for ( int ch = 0; ch < 2; ++ch )
+                  {
+                  uint8_t byte = chBytes[ ch ][ i >> 1 ];
+                  int nibble = ( i & 1 ) ? ( byte >> 4 ) : ( byte & 0x0f );
+                  predictor[ ch ] = MV_DecodeIMAADPCMNibble( predictor[ ch ], &index[ ch ], nibble );
+                  }
+
+               decoded[ writeIndex++ ] = (int16_t)predictor[ 0 ];
+               decoded[ writeIndex++ ] = (int16_t)predictor[ 1 ];
+               --remaining;
+               }
+            }
+         }
+
+      offset += blockSize;
+      }
+
+   *decodedOut = decoded;
+   *decodedSamplesPerChannelOut = writeIndex / (uint32_t)channels;
+
+   return TRUE;
+   }
+
 
 /*---------------------------------------------------------------------
    Function: MV_ErrorString
@@ -404,6 +638,8 @@ IRAM_ATTR void MV_StopVoice( VoiceNode *voice )
 {
    VoiceNode* pPrev;
    VoiceNode* pNext;
+   void* rawdataptr = NULL;
+   int ownsRawData = FALSE;
 
    unsigned  flags;
 
@@ -412,6 +648,12 @@ IRAM_ATTR void MV_StopVoice( VoiceNode *voice )
 
    pPrev = voice->prev;
    pNext = voice->next;
+
+   ownsRawData = voice->ownsRawData;
+   rawdataptr = voice->rawdataptr;
+   voice->ownsRawData = FALSE;
+   voice->rawdataptr = NULL;
+   voice->rawdatasiz = 0;
 
    // move the voice from the play list to the free list
    LL_Remove( voice, next, prev );
@@ -432,6 +674,11 @@ IRAM_ATTR void MV_StopVoice( VoiceNode *voice )
 
 
    RestoreInterrupts( flags );
+
+   if ( ownsRawData && rawdataptr != NULL )
+      {
+      USRHOOKS_FreeMem( rawdataptr );
+      }
 }
 
 
@@ -1202,6 +1449,9 @@ VoiceNode *MV_AllocVoice
    while( MV_VoicePlaying( MV_VoiceHandle ) );
 
    voice->handle = MV_VoiceHandle;
+   voice->rawdataptr = NULL;
+   voice->rawdatasiz = 0;
+   voice->ownsRawData = FALSE;
 
    return( voice );
    }
@@ -2327,13 +2577,33 @@ int MV_PlayLoopedWAV
    )
 
    {
-   riff_header   *riff;
-   format_header *format;
-   data_header   *data;
-   VoiceNode     *voice;
-   int length;
-   int absloopend;
-   int absloopstart;
+   const uint8_t *fmtData = NULL;
+   uint32_t fmtSize = 0;
+   const uint8_t *dataPtr = NULL;
+   uint32_t dataSize = 0;
+   uint32_t wavLength;
+   uint32_t offset;
+
+   uint16_t wFormatTag;
+   uint16_t nChannels;
+   uint32_t nSamplesPerSec;
+   uint16_t nBlockAlign;
+   uint16_t nBitsPerSample;
+
+   VoiceNode *voice;
+   int bits;
+   char *nextBlock;
+   unsigned long blockLength;
+   unsigned long sampleLength;
+   long loopstartBytes;
+   long loopendBytes;
+   long absloopstart;
+   long absloopend;
+
+   int16_t *decodedPCM = NULL;
+   uint32_t decodedSamplesPerChannel = 0;
+   uint32_t decodedBytes = 0;
+   int ownsRawData = FALSE;
 
    if ( !MV_Installed )
       {
@@ -2341,40 +2611,133 @@ int MV_PlayLoopedWAV
       return( MV_Error );
       }
 
-   riff = ( riff_header * )ptr;
-
-   if ( ( strncmp( riff->RIFF, "RIFF", 4 ) != 0 ) ||
-      ( strncmp( riff->WAVE, "WAVE", 4 ) != 0 ) ||
-      ( strncmp( riff->fmt, "fmt ", 4) != 0 ) )
+   if ( ptr == NULL )
       {
       MV_SetErrorCode( MV_InvalidWAVFile );
       return( MV_Error );
       }
 
-   format = ( format_header * )( riff + 1 );
-   data   = ( data_header * )( ( ( char * )format ) + riff->format_size );
-
-   // Check if it's PCM data.
-   if ( format->wFormatTag != 1 )
+   if ( memcmp( ptr, "RIFF", 4 ) != 0 || memcmp( ptr + 8, "WAVE", 4 ) != 0 )
       {
       MV_SetErrorCode( MV_InvalidWAVFile );
       return( MV_Error );
       }
 
-   if ( format->nChannels != 1 )
+   wavLength = MV_ReadLE32( ptr + 4 ) + 8;
+   if ( wavLength < 12 )
       {
       MV_SetErrorCode( MV_InvalidWAVFile );
       return( MV_Error );
       }
 
-   if ( ( format->nBitsPerSample != 8 ) &&
-      ( format->nBitsPerSample != 16 ) )
+   offset = 12;
+   while ( offset + 8 <= wavLength )
+      {
+      const uint8_t *chunk = ptr + offset;
+      uint32_t chunkSize = MV_ReadLE32( chunk + 4 );
+      uint32_t chunkDataOffset = offset + 8;
+      uint32_t chunkPaddedSize = chunkSize + ( chunkSize & 1 );
+
+      if ( chunkDataOffset > wavLength || chunkSize > wavLength - chunkDataOffset )
+         {
+         MV_SetErrorCode( MV_InvalidWAVFile );
+         return( MV_Error );
+         }
+
+      if ( memcmp( chunk, "fmt ", 4 ) == 0 )
+         {
+         fmtData = chunk + 8;
+         fmtSize = chunkSize;
+         }
+      else if ( memcmp( chunk, "data", 4 ) == 0 )
+         {
+         dataPtr = chunk + 8;
+         dataSize = chunkSize;
+         break;
+         }
+
+      if ( chunkDataOffset + chunkPaddedSize < chunkDataOffset )
+         {
+         MV_SetErrorCode( MV_InvalidWAVFile );
+         return( MV_Error );
+         }
+
+      offset = chunkDataOffset + chunkPaddedSize;
+      }
+
+   if ( fmtData == NULL || fmtSize < 16 || dataPtr == NULL || dataSize == 0 )
       {
       MV_SetErrorCode( MV_InvalidWAVFile );
       return( MV_Error );
       }
 
-   if ( strncmp( data->DATA, "data", 4 ) != 0 )
+   wFormatTag = MV_ReadLE16( fmtData + 0 );
+   nChannels = MV_ReadLE16( fmtData + 2 );
+   nSamplesPerSec = MV_ReadLE32( fmtData + 4 );
+   nBlockAlign = MV_ReadLE16( fmtData + 12 );
+   nBitsPerSample = MV_ReadLE16( fmtData + 14 );
+
+   // This mixer path only supports mono source files.
+   if ( nChannels != 1 )
+      {
+      MV_SetErrorCode( MV_InvalidWAVFile );
+      return( MV_Error );
+      }
+
+   if ( wFormatTag == 1 )
+      {
+      if ( ( nBitsPerSample != 8 && nBitsPerSample != 16 ) || nBlockAlign == 0 )
+         {
+         MV_SetErrorCode( MV_InvalidWAVFile );
+         return( MV_Error );
+         }
+
+      bits = nBitsPerSample;
+      nextBlock = (char *)dataPtr;
+
+      if ( bits == 16 )
+         {
+         dataSize &= ~1u;
+         sampleLength = dataSize / 2;
+         }
+      else
+         {
+         sampleLength = dataSize;
+         }
+      }
+   else if ( wFormatTag == 0x0011 )
+      {
+      int samplesPerBlock;
+
+      if ( fmtSize < 20 || nBlockAlign == 0 )
+         {
+         MV_SetErrorCode( MV_InvalidWAVFile );
+         return( MV_Error );
+         }
+
+      samplesPerBlock = MV_ReadLE16( fmtData + 18 );
+      if ( samplesPerBlock <= 0 )
+         {
+         MV_SetErrorCode( MV_InvalidWAVFile );
+         return( MV_Error );
+         }
+
+      if ( !MV_DecodeWAVIMAADPCM( dataPtr, dataSize, nChannels, nBlockAlign,
+         samplesPerBlock, &decodedPCM, &decodedSamplesPerChannel ) ||
+         decodedPCM == NULL || decodedSamplesPerChannel == 0 )
+         {
+         MV_SetErrorCode( MV_InvalidWAVFile );
+         return( MV_Error );
+         }
+
+      bits = 16;
+      decodedBytes = decodedSamplesPerChannel * sizeof( int16_t );
+      nextBlock = (char *)decodedPCM;
+      sampleLength = decodedSamplesPerChannel;
+      dataSize = decodedBytes;
+      ownsRawData = TRUE;
+      }
+   else
       {
       MV_SetErrorCode( MV_InvalidWAVFile );
       return( MV_Error );
@@ -2384,27 +2747,34 @@ int MV_PlayLoopedWAV
    voice = MV_AllocVoice( priority );
    if ( voice == NULL )
       {
+      if ( ownsRawData && decodedPCM != NULL )
+         {
+         USRHOOKS_FreeMem( decodedPCM );
+         }
+
       MV_SetErrorCode( MV_NoVoices );
       return( MV_Error );
       }
 
-   voice->wavetype    = WAV;
-   voice->bits        = format->nBitsPerSample;
-   voice->GetSound    = MV_GetNextWAVBlock;
-
-   length = data->size;
+   loopstartBytes = loopstart;
+   loopendBytes = loopend;
    absloopstart = loopstart;
-   absloopend   = loopend;
-   if ( voice->bits == 16 )
+   absloopend = loopend;
+
+   if ( bits == 16 )
       {
-      loopstart  *= 2;
-      data->size &= ~1;
-      loopend    *= 2;
-      length     /= 2;
+      loopstartBytes *= 2;
+      loopendBytes *= 2;
       }
 
-   loopend    = min( loopend, data->size );
-   absloopend = min( absloopend, length );
+   loopendBytes = min( loopendBytes, (long)dataSize );
+   absloopend = min( absloopend, (long)sampleLength );
+
+   blockLength = absloopend;
+
+   voice->wavetype    = WAV;
+   voice->bits        = bits;
+   voice->GetSound    = MV_GetNextWAVBlock;
 
    voice->Playing     = TRUE;
    voice->DemandFeed  = NULL;
@@ -2412,8 +2782,8 @@ int MV_PlayLoopedWAV
    voice->LoopCount   = 0;
    voice->position    = 0;
    voice->length      = 0;
-   voice->BlockLength = absloopend;
-   voice->NextBlock   = ( char * )( data + 1 );
+   voice->BlockLength = blockLength;
+   voice->NextBlock   = nextBlock;
    voice->next        = NULL;
    voice->prev        = NULL;
    voice->priority    = priority;
@@ -2424,18 +2794,22 @@ int MV_PlayLoopedWAV
    voice->GVal[2]     = 0;
    voice->GVal[3]     = 0;
    voice->callbackval = callbackval;
-   voice->LoopStart   = voice->NextBlock + loopstart;
-   voice->LoopEnd     = voice->NextBlock + loopend;
+   voice->rawdataptr  = ownsRawData ? (void *)decodedPCM : (void *)ptr;
+   voice->rawdatasiz  = ownsRawData ? decodedBytes : wavLength;
+   voice->ownsRawData = ownsRawData;
+
+   voice->LoopStart   = voice->NextBlock + loopstartBytes;
+   voice->LoopEnd     = voice->NextBlock + loopendBytes;
    voice->LoopSize    = absloopend - absloopstart;
 
-   if ( ( loopstart >= data->size ) || ( loopstart < 0 ) )
+   if ( ( loopstartBytes >= (long)dataSize ) || ( loopstartBytes < 0 ) )
       {
       voice->LoopStart = NULL;
       voice->LoopEnd   = NULL;
-      voice->BlockLength = length;
+      voice->BlockLength = sampleLength;
       }
 
-   MV_SetVoicePitch( voice, format->nSamplesPerSec, pitchoffset );
+   MV_SetVoicePitch( voice, nSamplesPerSec, pitchoffset );
    MV_SetVoiceVolume( voice, vol, left, right );
    MV_PlayVoice( voice );
 

--- a/duke3d-go/components/audiolib/multivoc.c
+++ b/duke3d-go/components/audiolib/multivoc.c
@@ -169,46 +169,123 @@ static uint32_t MV_ReadLE32( const uint8_t *p )
    return (uint32_t)( p[0] | ( p[1] << 8 ) | ( p[2] << 16 ) | ( p[3] << 24 ) );
 }
 
-static int MV_DecodeIMAADPCMNibble( int predictor, int *index, int nibble )
+static const int MV_IMAADPCMStepTable[ 89 ] =
 {
-   static const int indexTable[ 16 ] =
-   {
-      -1, -1, -1, -1, 2, 4, 6, 8,
-      -1, -1, -1, -1, 2, 4, 6, 8,
-   };
+      7,     8,     9,    10,    11,    12,    13,    14,
+     16,    17,    19,    21,    23,    25,    28,    31,
+     34,    37,    41,    45,    50,    55,    60,    66,
+     73,    80,    88,    97,   107,   118,   130,   143,
+    157,   173,   190,   209,   230,   253,   279,   307,
+    337,   371,   408,   449,   494,   544,   598,   658,
+    724,   796,   876,   963,  1060,  1166,  1282,  1411,
+   1552,  1707,  1878,  2066,  2272,  2499,  2749,  3024,
+   3327,  3660,  4026,  4428,  4871,  5358,  5894,  6484,
+   7132,  7845,  8630,  9493, 10442, 11487, 12635, 13899,
+  15289, 16818, 18500, 20350, 22385, 24623, 27086, 29794,
+  32767,
+};
 
-   static const int stepTable[ 89 ] =
-   {
-         7,     8,     9,    10,    11,    12,    13,    14,
-        16,    17,    19,    21,    23,    25,    28,    31,
-        34,    37,    41,    45,    50,    55,    60,    66,
-        73,    80,    88,    97,   107,   118,   130,   143,
-       157,   173,   190,   209,   230,   253,   279,   307,
-       337,   371,   408,   449,   494,   544,   598,   658,
-       724,   796,   876,   963,  1060,  1166,  1282,  1411,
-      1552,  1707,  1878,  2066,  2272,  2499,  2749,  3024,
-      3327,  3660,  4026,  4428,  4871,  5358,  5894,  6484,
-      7132,  7845,  8630,  9493, 10442, 11487, 12635, 13899,
-     15289, 16818, 18500, 20350, 22385, 24623, 27086, 29794,
-     32767,
-   };
+static int MV_DecodeIMAADPCMSymbol( int predictor, int *index, int code, int bitsPerSample )
+{
+   int step = MV_IMAADPCMStepTable[ *index ];
+   int delta;
 
-   int step = stepTable[ *index ];
-   int delta = step >> 3;
+   if ( bitsPerSample == 2 )
+      {
+      delta = step * ( code & 1 ) + ( step >> 1 );
+      predictor += ( code & 2 ) ? -delta : delta;
+      *index += ( ( code & 1 ) * 3 ) - 1;
+      }
+   else if ( bitsPerSample == 3 )
+      {
+      static const int indexTable3[ 4 ] = { -1, -1, 1, 2 };
 
-   if ( nibble & 1 ) delta += step >> 2;
-   if ( nibble & 2 ) delta += step >> 1;
-   if ( nibble & 4 ) delta += step;
+      delta = step >> 2;
+      if ( code & 1 ) delta += step >> 1;
+      if ( code & 2 ) delta += step;
 
-   predictor += ( nibble & 8 ) ? -delta : delta;
+      predictor += ( code & 4 ) ? -delta : delta;
+      *index += indexTable3[ code & 3 ];
+      }
+   else
+      {
+      static const int indexTable4[ 8 ] = { -1, -1, -1, -1, 2, 4, 6, 8 };
+
+      delta = step >> 3;
+      if ( code & 1 ) delta += step >> 2;
+      if ( code & 2 ) delta += step >> 1;
+      if ( code & 4 ) delta += step;
+
+      predictor += ( code & 8 ) ? -delta : delta;
+      *index += indexTable4[ code & 7 ];
+      }
+
    predictor = max( predictor, -32768 );
    predictor = min( predictor, 32767 );
 
-   *index += indexTable[ nibble & 15 ];
    *index = max( *index, 0 );
    *index = min( *index, 88 );
 
    return predictor;
+}
+
+static int MV_ReadIMAADPCMChannelByte(
+   const uint8_t *encoded,
+   int encodedBytes,
+   int channels,
+   int ch,
+   int j,
+   uint8_t *outByte )
+{
+   int byteIndex;
+
+   if ( channels == 1 )
+      {
+      byteIndex = j;
+      }
+   else
+      {
+      byteIndex = ( j & ~3 ) * channels + ( ch * 4 ) + ( j & 3 );
+      }
+
+   if ( byteIndex < 0 || byteIndex >= encodedBytes )
+      {
+      return FALSE;
+      }
+
+   *outByte = encoded[ byteIndex ];
+   return TRUE;
+}
+
+static int MV_ReadIMAADPCMSymbol(
+   const uint8_t *encoded,
+   int encodedBytes,
+   int channels,
+   int ch,
+   int bitsPerSample,
+   int symbolIndex,
+   int *outCode )
+{
+   int bitPos = symbolIndex * bitsPerSample;
+   int code = 0;
+
+   for ( int b = 0; b < bitsPerSample; ++b )
+      {
+      int absoluteBit = bitPos + b;
+      int bytePos = absoluteBit >> 3;
+      int bitInByte = absoluteBit & 7;
+      uint8_t byteVal;
+
+      if ( !MV_ReadIMAADPCMChannelByte( encoded, encodedBytes, channels, ch, bytePos, &byteVal ) )
+         {
+         return FALSE;
+         }
+
+      code |= ( ( byteVal >> bitInByte ) & 1 ) << b;
+      }
+
+   *outCode = code;
+   return TRUE;
 }
 
 static int MV_DecodeWAVIMAADPCM
@@ -217,17 +294,17 @@ static int MV_DecodeWAVIMAADPCM
    uint32_t dataSize,
    int channels,
    int blockAlign,
-   int samplesPerBlock,
+   int bitsPerSample,
+   int samplesPerBlockFromFmt,
    int16_t **decodedOut,
    uint32_t *decodedSamplesPerChannelOut
    )
 
    {
-   uint32_t blocks;
-   uint64_t maxSamples;
-   uint64_t maxBytes;
-   int16_t *decoded;
    uint32_t offset;
+   uint64_t totalSamples;
+   uint64_t totalBytes;
+   int16_t *decoded;
    uint32_t writeIndex;
 
    if ( decodedOut == NULL || decodedSamplesPerChannelOut == NULL )
@@ -238,60 +315,97 @@ static int MV_DecodeWAVIMAADPCM
    *decodedOut = NULL;
    *decodedSamplesPerChannelOut = 0;
 
-   if ( ( channels != 1 && channels != 2 ) || blockAlign <= 0 || samplesPerBlock <= 0 || dataSize == 0 )
+   if ( dataPtr == NULL || dataSize == 0 || ( channels != 1 && channels != 2 ) || blockAlign <= 0 )
       {
       return FALSE;
       }
 
-   if ( ( dataSize % (uint32_t)blockAlign ) != 0 )
+   if ( bitsPerSample != 2 && bitsPerSample != 3 && bitsPerSample != 4 )
       {
       return FALSE;
       }
 
-   blocks = dataSize / (uint32_t)blockAlign;
-   if ( blocks == 0 )
-      {
-      return FALSE;
-      }
-
-   maxSamples = (uint64_t)blocks * (uint64_t)samplesPerBlock * (uint64_t)channels;
-   maxBytes = maxSamples * sizeof( int16_t );
-
-   if ( maxBytes == 0 || maxBytes > 0xffffffffu )
-      {
-      return FALSE;
-      }
-
-   if ( USRHOOKS_GetMem( ( void ** )&decoded, (uint32_t)maxBytes ) != USRHOOKS_Ok || decoded == NULL )
-      {
-      return FALSE;
-      }
-
+   totalSamples = 0;
    offset = 0;
+
+   while ( offset < dataSize )
+      {
+      uint32_t remainingBytes = dataSize - offset;
+      uint32_t actualBlockSize = min( (uint32_t)blockAlign, remainingBytes );
+      int headerSize = 4 * channels;
+      int encodedBytes;
+      int bytesPerChannel;
+      int derivedSamplesPerBlock;
+      int blockSamplesPerChannel;
+
+      if ( actualBlockSize < (uint32_t)headerSize )
+         {
+         break;
+         }
+
+      encodedBytes = (int)actualBlockSize - headerSize;
+      bytesPerChannel = encodedBytes / channels;
+      derivedSamplesPerBlock = 1 + ( bytesPerChannel * 8 ) / bitsPerSample;
+
+      if ( samplesPerBlockFromFmt > 0 )
+         {
+         blockSamplesPerChannel = min( samplesPerBlockFromFmt, derivedSamplesPerBlock );
+         }
+      else
+         {
+         blockSamplesPerChannel = derivedSamplesPerBlock;
+         }
+
+      if ( blockSamplesPerChannel > 0 )
+         {
+         totalSamples += (uint64_t)blockSamplesPerChannel * (uint64_t)channels;
+         }
+
+      offset += actualBlockSize;
+      }
+
+   if ( totalSamples == 0 )
+      {
+      return FALSE;
+      }
+
+   totalBytes = totalSamples * sizeof( int16_t );
+   if ( totalBytes > 0xffffffffu )
+      {
+      return FALSE;
+      }
+
+   if ( USRHOOKS_GetMem( ( void ** )&decoded, (uint32_t)totalBytes ) != USRHOOKS_Ok || decoded == NULL )
+      {
+      return FALSE;
+      }
+
    writeIndex = 0;
+   offset = 0;
 
    while ( offset < dataSize )
       {
       const uint8_t *block = dataPtr + offset;
-      uint32_t blockSize = (uint32_t)blockAlign;
+      uint32_t remainingBytes = dataSize - offset;
+      uint32_t actualBlockSize = min( (uint32_t)blockAlign, remainingBytes );
       int headerSize = 4 * channels;
       int predictor[ 2 ] = { 0, 0 };
       int index[ 2 ] = { 0, 0 };
+      const uint8_t *encoded;
+      int encodedBytes;
+      int bytesPerChannel;
       int derivedSamplesPerBlock;
       int blockSamplesPerChannel;
-      int remaining;
-      const uint8_t *src;
-      const uint8_t *srcEnd;
 
-      if ( blockSize < (uint32_t)headerSize )
+      if ( actualBlockSize < (uint32_t)headerSize )
          {
-         USRHOOKS_FreeMem( decoded );
-         return FALSE;
+         break;
          }
 
       for ( int ch = 0; ch < channels; ++ch )
          {
          const uint8_t *hdr = block + ( ch * 4 );
+
          predictor[ ch ] = (int)(int16_t)MV_ReadLE16( hdr );
          index[ ch ] = (int)hdr[ 2 ];
 
@@ -302,89 +416,49 @@ static int MV_DecodeWAVIMAADPCM
             }
          }
 
-      derivedSamplesPerBlock = 1 + ( ( (int)blockSize - headerSize ) * 2 ) / channels;
-      if ( derivedSamplesPerBlock <= 0 )
+      encoded = block + headerSize;
+      encodedBytes = (int)actualBlockSize - headerSize;
+      bytesPerChannel = encodedBytes / channels;
+      derivedSamplesPerBlock = 1 + ( bytesPerChannel * 8 ) / bitsPerSample;
+
+      if ( samplesPerBlockFromFmt > 0 )
          {
-         USRHOOKS_FreeMem( decoded );
-         return FALSE;
-         }
-
-      blockSamplesPerChannel = min( samplesPerBlock, derivedSamplesPerBlock );
-      if ( blockSamplesPerChannel <= 0 )
-         {
-         USRHOOKS_FreeMem( decoded );
-         return FALSE;
-         }
-
-      for ( int ch = 0; ch < channels; ++ch )
-         {
-         decoded[ writeIndex++ ] = (int16_t)predictor[ ch ];
-         }
-
-      remaining = blockSamplesPerChannel - 1;
-      src = block + headerSize;
-      srcEnd = block + blockSize;
-
-      if ( channels == 1 )
-         {
-         while ( remaining > 0 )
-            {
-            uint8_t byte;
-
-            if ( src >= srcEnd )
-               {
-               USRHOOKS_FreeMem( decoded );
-               return FALSE;
-               }
-
-            byte = *src++;
-
-            predictor[ 0 ] = MV_DecodeIMAADPCMNibble( predictor[ 0 ], &index[ 0 ], byte & 0x0f );
-            decoded[ writeIndex++ ] = (int16_t)predictor[ 0 ];
-            --remaining;
-            if ( remaining <= 0 )
-               {
-               break;
-               }
-
-            predictor[ 0 ] = MV_DecodeIMAADPCMNibble( predictor[ 0 ], &index[ 0 ], byte >> 4 );
-            decoded[ writeIndex++ ] = (int16_t)predictor[ 0 ];
-            --remaining;
-            }
+         blockSamplesPerChannel = min( samplesPerBlockFromFmt, derivedSamplesPerBlock );
          }
       else
          {
-         while ( remaining > 0 )
-            {
-            uint8_t chBytes[ 2 ][ 4 ];
+         blockSamplesPerChannel = derivedSamplesPerBlock;
+         }
 
-            if ( src + 8 > srcEnd )
+      if ( blockSamplesPerChannel > 0 )
+         {
+         for ( int ch = 0; ch < channels; ++ch )
+            {
+            decoded[ writeIndex++ ] = (int16_t)predictor[ ch ];
+            }
+         }
+
+      for ( int sampleIndex = 1; sampleIndex < blockSamplesPerChannel; ++sampleIndex )
+         {
+         int symbolIndex = sampleIndex - 1;
+
+         for ( int ch = 0; ch < channels; ++ch )
+            {
+            int code;
+
+            if ( !MV_ReadIMAADPCMSymbol( encoded, encodedBytes, channels, ch,
+               bitsPerSample, symbolIndex, &code ) )
                {
                USRHOOKS_FreeMem( decoded );
                return FALSE;
                }
 
-            memcpy( chBytes[ 0 ], src, 4 );
-            memcpy( chBytes[ 1 ], src + 4, 4 );
-            src += 8;
-
-            for ( int i = 0; i < 8 && remaining > 0; ++i )
-               {
-               for ( int ch = 0; ch < 2; ++ch )
-                  {
-                  uint8_t byte = chBytes[ ch ][ i >> 1 ];
-                  int nibble = ( i & 1 ) ? ( byte >> 4 ) : ( byte & 0x0f );
-                  predictor[ ch ] = MV_DecodeIMAADPCMNibble( predictor[ ch ], &index[ ch ], nibble );
-                  }
-
-               decoded[ writeIndex++ ] = (int16_t)predictor[ 0 ];
-               decoded[ writeIndex++ ] = (int16_t)predictor[ 1 ];
-               --remaining;
-               }
+            predictor[ ch ] = MV_DecodeIMAADPCMSymbol( predictor[ ch ], &index[ ch ], code, bitsPerSample );
+            decoded[ writeIndex++ ] = (int16_t)predictor[ ch ];
             }
          }
 
-      offset += blockSize;
+      offset += actualBlockSize;
       }
 
    *decodedOut = decoded;
@@ -2653,13 +2727,17 @@ int MV_PlayLoopedWAV
          {
          dataPtr = chunk + 8;
          dataSize = chunkSize;
-         break;
          }
 
       if ( chunkDataOffset + chunkPaddedSize < chunkDataOffset )
          {
          MV_SetErrorCode( MV_InvalidWAVFile );
          return( MV_Error );
+         }
+
+      if ( fmtData != NULL && dataPtr != NULL )
+         {
+         break;
          }
 
       offset = chunkDataOffset + chunkPaddedSize;
@@ -2677,8 +2755,7 @@ int MV_PlayLoopedWAV
    nBlockAlign = MV_ReadLE16( fmtData + 12 );
    nBitsPerSample = MV_ReadLE16( fmtData + 14 );
 
-   // This mixer path only supports mono source files.
-   if ( nChannels != 1 )
+   if ( nChannels < 1 || nChannels > 2 || nBlockAlign == 0 )
       {
       MV_SetErrorCode( MV_InvalidWAVFile );
       return( MV_Error );
@@ -2686,7 +2763,8 @@ int MV_PlayLoopedWAV
 
    if ( wFormatTag == 1 )
       {
-      if ( ( nBitsPerSample != 8 && nBitsPerSample != 16 ) || nBlockAlign == 0 )
+      // PCM source path is mono-only in this mixer implementation.
+      if ( nChannels != 1 || ( nBitsPerSample != 8 && nBitsPerSample != 16 ) )
          {
          MV_SetErrorCode( MV_InvalidWAVFile );
          return( MV_Error );
@@ -2707,23 +2785,26 @@ int MV_PlayLoopedWAV
       }
    else if ( wFormatTag == 0x0011 )
       {
-      int samplesPerBlock;
+      int samplesPerBlockFromFmt = 0;
+      uint16_t cbSize = 0;
 
-      if ( fmtSize < 20 || nBlockAlign == 0 )
+      if ( nBitsPerSample != 2 && nBitsPerSample != 3 && nBitsPerSample != 4 )
          {
          MV_SetErrorCode( MV_InvalidWAVFile );
          return( MV_Error );
          }
 
-      samplesPerBlock = MV_ReadLE16( fmtData + 18 );
-      if ( samplesPerBlock <= 0 )
+      if ( fmtSize >= 20 )
          {
-         MV_SetErrorCode( MV_InvalidWAVFile );
-         return( MV_Error );
+         cbSize = MV_ReadLE16( fmtData + 16 );
+         if ( cbSize >= 2 && fmtSize >= 22 )
+            {
+            samplesPerBlockFromFmt = MV_ReadLE16( fmtData + 18 );
+            }
          }
 
       if ( !MV_DecodeWAVIMAADPCM( dataPtr, dataSize, nChannels, nBlockAlign,
-         samplesPerBlock, &decodedPCM, &decodedSamplesPerChannel ) ||
+         nBitsPerSample, samplesPerBlockFromFmt, &decodedPCM, &decodedSamplesPerChannel ) ||
          decodedPCM == NULL || decodedSamplesPerChannel == 0 )
          {
          MV_SetErrorCode( MV_InvalidWAVFile );
@@ -2731,9 +2812,9 @@ int MV_PlayLoopedWAV
          }
 
       bits = 16;
-      decodedBytes = decodedSamplesPerChannel * sizeof( int16_t );
+      decodedBytes = decodedSamplesPerChannel * (uint32_t)nChannels * sizeof( int16_t );
       nextBlock = (char *)decodedPCM;
-      sampleLength = decodedSamplesPerChannel;
+      sampleLength = decodedSamplesPerChannel * (uint32_t)nChannels;
       dataSize = decodedBytes;
       ownsRawData = TRUE;
       }

--- a/duke3d-go/components/duke3d/Engine/engine.c
+++ b/duke3d-go/components/duke3d/Engine/engine.c
@@ -84,6 +84,8 @@ int32_t lastageclock;
 EXT_RAM_BSS_ATTR int32_t tilefileoffs[MAXTILES];
 
 int32_t artsize = 0, cachesize = 0;
+EXT_RAM_BSS_ATTR static uint8_t palookup0_static[MAXPALOOKUPS << 8];
+EXT_RAM_BSS_ATTR static uint8_t transluc_static[65536];
 
 EXT_RAM_BSS_ATTR static short radarang[1280], radarang2[MAXXDIM+1];
 EXT_RAM_BSS_ATTR static uint16_t sqrtable[4096], shlookup[4096+256];
@@ -3575,12 +3577,12 @@ static void loadpalette(void)
     //CODE EXPLORATION
     printf("Num palettes lookup: %d.\n",numpalookups);
 
-    if ((palookup[0] = (uint8_t  *)kkmalloc(numpalookups<<8)) == NULL)
-        allocache(&palookup[0],numpalookups<<8,&permanentlock);
+    // Keep these core lookup tables in static external RAM so startup doesn't
+    // depend on cache initialization order or large contiguous heap blocks.
+    palookup[0] = palookup0_static;
 
-    //Transluctent pallete is 65KB.
-    if ((transluc = (uint8_t  *)kkmalloc(65536)) == NULL)
-        allocache(&transluc,65536,&permanentlock);
+    // Translucent palette is 64KB.
+    transluc = transluc_static;
 
     globalpalwritten = palookup[0];
     globalpal = 0;
@@ -3639,8 +3641,7 @@ void initengine(void)
     for(i=0; i<MAXPALOOKUPS; i++)
         palookup[i] = NULL;
 
-    tiles = rg_alloc(sizeof(tile_t) * MAXTILES, MEM_SLOW);
-    // printf("initengine: tiles=%p, sector=%p, wall=%p, sprite=%p\n", tiles, sector, wall, sprite);
+    // tiles storage is static in external RAM (see tiles.c) to avoid runtime SPIRAM heap spikes.
     for(i=0 ; i < MAXTILES ; i++)
         tiles[i].data = NULL;
 
@@ -3665,10 +3666,7 @@ void initengine(void)
 
 void uninitengine(void)
 {
-    if (transluc != NULL) {
-        kkfree(transluc);
-        transluc = NULL;
-    }
+    transluc = NULL;
     if (pic != NULL) {
         kkfree(pic);
         pic = NULL;

--- a/duke3d-go/components/duke3d/Engine/filesystem.c
+++ b/duke3d-go/components/duke3d/Engine/filesystem.c
@@ -19,8 +19,6 @@
 
 #include "duke3d.h"
 #include <rg_system.h>
-#include <esp_timer.h>
-#include <esp_heap_caps.h>
 #include <inttypes.h>
 #include <ctype.h>
 
@@ -42,6 +40,8 @@ typedef struct grpArchive_s{
     int32_t  *fileOffsets         ;//Array containing the file offsets.
     int32_t  *filesizes           ;//Array containing the file offsets.
     int fileDescriptor            ;//The fd used for open,read operations.
+    const uint8_t *data           ;//Raw GRP data when archive is memory-backed.
+    uint8_t dataOwned             ;//If true, free(data) on uninit.
     uint32_t crc32                ;//Hash to recognize GRP: Duke Shareware, Duke plutonimum etc...
     
 } grpArchive_t;
@@ -57,80 +57,63 @@ typedef struct grpSet_s{
 static grpSet_t grpSet;
 
 
-int32_t initgroupfile(const char  *filename)
+static int32_t initgroupfile_common(grpArchive_t *archive, const char *name, int32_t totalLength)
 {
-	uint8_t         buf[16]                 ;
-	int32_t         i, j, k                 ;
-    grpArchive_t*   archive                 ;
-    
-    
-    
-	printf("Loading %s ...", filename); fflush(stdout);
-    
-	if (grpSet.num == MAXGROUPFILES){
-        printf("Error: Unable to open an extra GRP archive <= No more slot available.\n");
-        return(-1);
-    }
-    
-    archive = &grpSet.archives[grpSet.num];
-    
-    //Init the slot
-    memset(archive, 0, sizeof(grpArchive_t));
-    
-	//groupfil_memory[numgroupfiles] = NULL; // addresses of raw GRP files in memory
-	//groupefil_crc32[numgroupfiles] = 0;
-    SDL_LockDisplay();
-	archive->fileDescriptor = open(filename,O_BINARY|O_RDONLY,S_IREAD);
-    
-    if (archive->fileDescriptor < 0){
-        Error(EXIT_FAILURE, "Error: Unable to open file %s.\n",filename);
-    }
-    printf(" (fd=%d)\n", archive->fileDescriptor); fflush(stdout);
-    
-    
-    read(archive->fileDescriptor,buf,16);
+    int32_t i, j, k;
+    uint8_t header[16];
 
-    //FCS   : The ".grp" file format is just a collection of a lot of files stored into 1 big one.
-	//KS doc: I tried to make the format as simple as possible: The first 12 bytes contains my name,
-	//"KenSilverman". The next 4 bytes is the number of files that were compacted into the
-    //group file. Then for each file, there is a 16 byte structure, where the first 12
-    //bytes are the filename, and the last 4 bytes are the file's size. The rest of the
-    //group file is just the raw data packed one after the other in the same order as the list
-    //of files. - ken
-    
-    // Check the magic number (12 bytes header).
-    if ((buf[0] != 'K') || (buf[1] != 'e') || (buf[2] != 'n') ||
-        (buf[3] != 'S') || (buf[4] != 'i') || (buf[5] != 'l') ||
-        (buf[6] != 'v') || (buf[7] != 'e') || (buf[8] != 'r') ||
-        (buf[9] != 'm') || (buf[10] != 'a') || (buf[11] != 'n')){
-        printf("Error: File %s is not a GRP archive.\n",filename);
-        return(-1);
+    if (archive->data)
+    {
+        memcpy(header, archive->data, sizeof(header));
     }
-    
-    
-	
-    
+    else
+    {
+        SDL_LockDisplay();
+        lseek(archive->fileDescriptor, 0, SEEK_SET);
+        read(archive->fileDescriptor, header, sizeof(header));
+        SDL_UnlockDisplay();
+    }
+
+    // Check the magic number (12 bytes header).
+    if ((header[0] != 'K') || (header[1] != 'e') || (header[2] != 'n') ||
+        (header[3] != 'S') || (header[4] != 'i') || (header[5] != 'l') ||
+        (header[6] != 'v') || (header[7] != 'e') || (header[8] != 'r') ||
+        (header[9] != 'm') || (header[10] != 'a') || (header[11] != 'n'))
+    {
+        printf("Error: File %s is not a GRP archive.\n", name ? name : "<memory>");
+        return -1;
+    }
+
     // The next 4 bytes of the header feature the number of files in the GRP archive.
-    archive->numFiles = BUILDSWAP_INTEL32(*((int32_t *)&buf[12]));
-    
-    
+    archive->numFiles = BUILDSWAP_INTEL32(*((int32_t *)&header[12]));
+
     archive->gfilelist = malloc(archive->numFiles * sizeof(grpIndexEntry_t));
     archive->fileOffsets = malloc(archive->numFiles * sizeof(int32_t));
     archive->filesizes = malloc(archive->numFiles * sizeof(int32_t));
 
-    if (!archive->gfilelist || !archive->fileOffsets || !archive->filesizes) {
+    if (!archive->gfilelist || !archive->fileOffsets || !archive->filesizes)
+    {
         Error(EXIT_FAILURE, "Error: Memory allocation failed for GRP index.\n");
     }
-    
-    // Load the full index 16 bytes per file (12bytes for name + 4 bytes for the size).
-    read(archive->fileDescriptor,archive->gfilelist, archive->numFiles * 16);
+
+    if (archive->data)
+    {
+        memcpy(archive->gfilelist, archive->data + 16, archive->numFiles * 16);
+    }
+    else
+    {
+        SDL_LockDisplay();
+        lseek(archive->fileDescriptor, 16, SEEK_SET);
+        read(archive->fileDescriptor, archive->gfilelist, archive->numFiles * 16);
+        SDL_UnlockDisplay();
+    }
 
     //Initialize all file offset and pointers.
     j = 12 + 4 + archive->numFiles * sizeof(grpIndexEntry_t);
-    for(i=0;i<archive->numFiles;i++){
-        
+    for (i = 0; i < archive->numFiles; i++)
+    {
         k = BUILDSWAP_INTEL32(*((int32_t *)&archive->gfilelist[i][12])); // get size
-        
+
         // Now that the filesize has been read, we can replace it with '0' and hence have a
         // valid, null terminated character string that will be usable.
         archive->gfilelist[i][12] = '\0';
@@ -138,69 +121,106 @@ int32_t initgroupfile(const char  *filename)
         archive->fileOffsets[i] = j; // absolute offset list of all files.
         j += k;
     }
-    //archive->fileOffsets[archive->numFiles-1] = j;
-	
 
-	// Compute CRC32 of the whole grp and implicitely caches the GRP in memory through windows caching service.
-    // Rewind the fileDescriptor
-	lseek(archive->fileDescriptor, 0, SEEK_SET);
-
-	//i = 1000000;
-	//groupfil_memory[numgroupfiles] = malloc(i);
-    
-    //Load the full GRP in RAM.
-	//uint8_t         crcBuffer[ 1 << 20]     ;
-	// uint8_t *crcBuffer = malloc((1 << 20)*sizeof(uint8_t));
-//	while((j=read(archive->fileDescriptor, crcBuffer, /*sizeof(crcBuffer)*/(1 << 20)*sizeof(uint8_t) ))){
-/*		archive->crc32 = crc32_update(crcBuffer,j,archive->crc32);
-		SDL_UnlockDisplay();
-		SDL_LockDisplay();
-		printf(".");
-		fflush(stdout);
-	}
-*/	SDL_UnlockDisplay();
-	printf("\n");
-    // free(crcBuffer);
-
-// Instead of CRCs, use filesizes...
-	int32_t length = filelength(archive->fileDescriptor);
-	if(length == 44356548)
-	{
-		archive->crc32=CRC_BASE_GRP_ATOMIC_15;
-		printf("Version: Atomic 1.5\n");
-	} else if(length == 44348015)
-	{
-		archive->crc32=CRC_BASE_GRP_PLUTONIUM_14;
-		printf("Version: Plutonium 1.4\n");
-	} else if(length == 26524524)
-	{
-		archive->crc32=CRC_BASE_GRP_FULL_13;
-		printf("Version: Full 1.3d\n");
-	} else if(length == 11035779)
-	{
-		archive->crc32=CRC_BASE_GRP_SHAREWARE_13;
-		printf("Version: Shareware 1.3\n");
-	} else {
-		archive->crc32=CRC_BASE_GRP_ATOMIC_15;
-	}
-/*
-	archive->crc32=CRC_BASE_GRP_SHAREWARE_13 
-	archive->crc32=CRC_BASE_GRP_FULL_13 
-	archive->crc32=CRC_BASE_GRP_PLUTONIUM_14 
-	archive->crc32=CRC_BASE_GRP_ATOMIC_15 
-*/
+    if (totalLength == 44356548)
+    {
+        archive->crc32 = CRC_BASE_GRP_ATOMIC_15;
+        printf("Version: Atomic 1.5\n");
+    }
+    else if (totalLength == 44348015)
+    {
+        archive->crc32 = CRC_BASE_GRP_PLUTONIUM_14;
+        printf("Version: Plutonium 1.4\n");
+    }
+    else if (totalLength == 26524524)
+    {
+        archive->crc32 = CRC_BASE_GRP_FULL_13;
+        printf("Version: Full 1.3d\n");
+    }
+    else if (totalLength == 11035779)
+    {
+        archive->crc32 = CRC_BASE_GRP_SHAREWARE_13;
+        printf("Version: Shareware 1.3\n");
+    }
+    else
+    {
+        archive->crc32 = CRC_BASE_GRP_ATOMIC_15;
+    }
 
     // The game layer seems to absolutely need to access an array int[4] groupefil_crc32
     // so we need to store the crc32 in there too.
     groupefil_crc32[grpSet.num] = archive->crc32;
-    
-	//free(groupfil_memory[numgroupfiles]);
-	//groupfil_memory[numgroupfiles] = 0;
-    
-    grpSet.num++;
 
-	return(grpSet.num-1);
-    
+    grpSet.num++;
+    return (grpSet.num - 1);
+}
+
+int32_t initgroupfile(const char  *filename)
+{
+    grpArchive_t *archive;
+
+    printf("Loading %s ...", filename); fflush(stdout);
+
+    if (grpSet.num == MAXGROUPFILES)
+    {
+        printf("Error: Unable to open an extra GRP archive <= No more slot available.\n");
+        return -1;
+    }
+
+    archive = &grpSet.archives[grpSet.num];
+
+    //Init the slot
+    memset(archive, 0, sizeof(grpArchive_t));
+    archive->fileDescriptor = -1;
+
+    SDL_LockDisplay();
+    archive->fileDescriptor = open(filename, O_BINARY | O_RDONLY, S_IREAD);
+    SDL_UnlockDisplay();
+
+    if (archive->fileDescriptor < 0)
+    {
+        Error(EXIT_FAILURE, "Error: Unable to open file %s.\n", filename);
+    }
+    printf(" (fd=%d)\n", archive->fileDescriptor); fflush(stdout);
+
+    int32_t length = filelength(archive->fileDescriptor);
+    archive->data = NULL;
+    archive->dataOwned = 0;
+
+    printf("\n");
+    return initgroupfile_common(archive, filename, length);
+}
+
+int32_t initgroupfile_from_memory(const char *name, const void *data, int32_t size)
+{
+    grpArchive_t *archive;
+
+    if (!data || size < 16)
+    {
+        return -1;
+    }
+
+    if (grpSet.num == MAXGROUPFILES)
+    {
+        printf("Error: Unable to open an extra GRP archive <= No more slot available.\n");
+        return -1;
+    }
+
+    archive = &grpSet.archives[grpSet.num];
+    memset(archive, 0, sizeof(grpArchive_t));
+    archive->fileDescriptor = -1;
+    archive->data = (const uint8_t *)data;
+    archive->dataOwned = 1;
+
+    printf("Loading %s from RAM ...\n", name ? name : "<memory>");
+    return initgroupfile_common(archive, name, size);
+}
+
+int32_t groupfile_primary_is_memory_backed(void)
+{
+    if (grpSet.num <= 0)
+        return 0;
+    return grpSet.archives[0].data != NULL;
 }
 
 void uninitgroupfile(void)
@@ -208,11 +228,15 @@ void uninitgroupfile(void)
 	int i;
     
 	for( i=0 ; i < grpSet.num ;i++){
-        free(grpSet.archives[i].gfilelist);
-        free(grpSet.archives[i].fileOffsets);
-        free(grpSet.archives[i].filesizes);
-        memset(&grpSet.archives[i], 0, sizeof(grpArchive_t));
-    }
+	       if (grpSet.archives[i].fileDescriptor >= 0)
+	           close(grpSet.archives[i].fileDescriptor);
+	       if (grpSet.archives[i].dataOwned)
+	           free((void *)grpSet.archives[i].data);
+	       free(grpSet.archives[i].gfilelist);
+	       free(grpSet.archives[i].fileOffsets);
+	       free(grpSet.archives[i].filesizes);
+	       memset(&grpSet.archives[i], 0, sizeof(grpArchive_t));
+	   }
     
 }
 
@@ -416,6 +440,14 @@ int32_t kread(int32_t handle, void *buffer, int32_t leng){
         totalToRead = min(leng, archive->filesizes[openFile->fd] - openFile->cursor);
     }
     if (totalToRead <= 0) return 0;
+
+    if (openFile->type == GRP_FILE && archive->data)
+    {
+        const uint8_t *src = archive->data + archive->fileOffsets[openFile->fd] + openFile->cursor;
+        memcpy(buffer, src, totalToRead);
+        openFile->cursor += totalToRead;
+        return totalToRead;
+    }
 
     // Use buffer for small reads or if already buffered
     if (totalToRead < KREAD_BUFFER_SIZE || openFile->buffer != NULL) {

--- a/duke3d-go/components/duke3d/Engine/filesystem.h
+++ b/duke3d-go/components/duke3d/Engine/filesystem.h
@@ -20,6 +20,8 @@
 extern int32_t groupefil_crc32[MAXGROUPFILES];
 
 int32_t  initgroupfile(const char  *filename);
+int32_t  initgroupfile_from_memory(const char *name, const void *data, int32_t size);
+int32_t  groupfile_primary_is_memory_backed(void);
 void     uninitgroupfile(void);
 uint16_t crc16(uint8_t  *data_p, uint16_t length);
 uint32_t crc32_update(uint8_t  *buf, uint32_t length, uint32_t crc_to_update);

--- a/duke3d-go/components/duke3d/Engine/tiles.c
+++ b/duke3d-go/components/duke3d/Engine/tiles.c
@@ -321,7 +321,7 @@ static int try_loadtile_from_override_png(short tilenume)
     unsigned err;
     uint8_t *dst;
     int32_t pixelCount;
-    int32_t i;
+    int32_t x, y;
 
     const char *overrideFile;
 
@@ -400,13 +400,18 @@ static int try_loadtile_from_override_png(short tilenume)
     }
 
     dst = tiles[tilenume].data;
-    for (i = 0; i < pixelCount; i++)
+    for (y = 0; y < (int32_t)height; y++)
     {
-        const uint8_t r = rgba[i * 4 + 0];
-        const uint8_t g = rgba[i * 4 + 1];
-        const uint8_t b = rgba[i * 4 + 2];
-        const uint8_t a = rgba[i * 4 + 3];
-        dst[i] = (a < 128) ? 255 : nearest_palette_index(r, g, b);
+        for (x = 0; x < (int32_t)width; x++)
+        {
+            const int32_t srcIndex = (y * (int32_t)width + x) * 4;
+            const int32_t dstIndex = x * (int32_t)height + y;
+            const uint8_t r = rgba[srcIndex + 0];
+            const uint8_t g = rgba[srcIndex + 1];
+            const uint8_t b = rgba[srcIndex + 2];
+            const uint8_t a = rgba[srcIndex + 3];
+            dst[dstIndex] = (a < 128) ? 255 : nearest_palette_index(r, g, b);
+        }
     }
 
     free(rgba);

--- a/duke3d-go/components/duke3d/Engine/tiles.c
+++ b/duke3d-go/components/duke3d/Engine/tiles.c
@@ -20,7 +20,8 @@
 
 char  artfilename[20];
 
-tile_t *tiles;//[MAXTILES];
+static EXT_RAM_BSS_ATTR tile_t tiles_static[MAXTILES];
+tile_t *tiles = tiles_static;
 
 int32_t numTiles;
 
@@ -970,7 +971,10 @@ int loadpics(char  *filename, char * gamedir)
 
     clearbuf(gotpic,(MAXTILES+31)>>5,0L);
 
-    cachesize = max(artsize,1048576);
+    // When the primary GRP is memory-backed (ZIP extracted to RAM), use a
+    // moderate cache floor to improve runtime reuse while staying memory-safe.
+    const int32_t min_cache_size = groupfile_primary_is_memory_backed() ? (512 * 1024) : (1024 * 1024);
+    cachesize = max(artsize, min_cache_size);
     cachesize = (cachesize + 15) & ~15; // Align size to 16 bytes
 
 #ifdef CONFIG_IDF_TARGET_ESP32

--- a/duke3d-go/components/duke3d/Engine/tiles.c
+++ b/duke3d-go/components/duke3d/Engine/tiles.c
@@ -33,6 +33,8 @@ EXT_RAM_BSS_ATTR uint8_t  gotpic[(MAXTILES+7)>>3];
 #define TILE_OVERRIDE_NAME_MAX 128
 #define MAX_ART_FILES_SCAN 1000
 #define ART_MISS_STREAK_STOP 32
+#define PNG_HEADER_READ_SIZE 33
+#define OVERRIDE_PAL_CACHE_SLOTS 4096
 
 typedef struct tile_override_s {
     short tileId;
@@ -41,6 +43,10 @@ typedef struct tile_override_s {
 } tile_override_t;
 
 static tile_override_t *tileOverridesHead = NULL;
+
+EXT_RAM_BSS_ATTR static uint32_t overridePalCacheKey[OVERRIDE_PAL_CACHE_SLOTS];
+EXT_RAM_BSS_ATTR static uint8_t overridePalCacheValue[OVERRIDE_PAL_CACHE_SLOTS];
+static int overridePalCacheInit = 0;
 
 static int ci_starts_with(const char *s, const char *prefix)
 {
@@ -284,6 +290,122 @@ static void parse_tile_overrides_from_def(void)
     }
 }
 
+static uint32_t read_be_u32(const uint8_t *p)
+{
+    return ((uint32_t)p[0] << 24) |
+           ((uint32_t)p[1] << 16) |
+           ((uint32_t)p[2] << 8) |
+           ((uint32_t)p[3] << 0);
+}
+
+static int read_png_dimensions(const char *fileName, short *outWidth, short *outHeight)
+{
+    int32_t fileHandle;
+    uint8_t header[PNG_HEADER_READ_SIZE];
+    uint32_t width, height;
+
+    if (!fileName || !outWidth || !outHeight)
+        return 0;
+
+    fileHandle = TCkopen4load(fileName, 0);
+    if (fileHandle == -1)
+        return 0;
+
+    if (kread(fileHandle, header, PNG_HEADER_READ_SIZE) != PNG_HEADER_READ_SIZE)
+    {
+        kclose(fileHandle);
+        return 0;
+    }
+    kclose(fileHandle);
+
+    if (memcmp(header, "\x89PNG\r\n\x1a\n", 8) != 0)
+        return 0;
+
+    if (read_be_u32(&header[8]) != 13 || memcmp(&header[12], "IHDR", 4) != 0)
+        return 0;
+
+    width = read_be_u32(&header[16]);
+    height = read_be_u32(&header[20]);
+
+    if ((width == 0) || (height == 0) || (width > 32767) || (height > 32767))
+        return 0;
+
+    *outWidth = (short)width;
+    *outHeight = (short)height;
+    return 1;
+}
+
+static void prime_tile_override_metadata_from_png_headers(void)
+{
+    tile_override_t *entry;
+    int32_t okCount = 0;
+    int32_t failCount = 0;
+    int32_t mismatchCount = 0;
+    int32_t logBudget = 32;
+
+    for (entry = tileOverridesHead; entry != NULL; entry = entry->next)
+    {
+        short w = 0, h = 0;
+
+        if (read_png_dimensions(entry->fileName, &w, &h))
+        {
+            if (tiles[entry->tileId].dim.width <= 0 || tiles[entry->tileId].dim.height <= 0)
+            {
+                int j;
+                tiles[entry->tileId].dim.width = w;
+                tiles[entry->tileId].dim.height = h;
+
+                j = 15;
+                while ((j > 1) && (pow2long[j] > (int32_t)w))
+                    j--;
+                picsiz[entry->tileId] = (uint8_t)j;
+
+                j = 15;
+                while ((j > 1) && (pow2long[j] > (int32_t)h))
+                    j--;
+                picsiz[entry->tileId] += (uint8_t)(j << 4);
+                okCount++;
+            }
+            else
+            {
+                if ((tiles[entry->tileId].dim.width != w) || (tiles[entry->tileId].dim.height != h))
+                {
+                    mismatchCount++;
+                    if (logBudget > 0)
+                    {
+                        logBudget--;
+                        printf("loadpics: override tile %d PNG=%dx%d differs from tile metadata=%dx%d (will scale at decode)\n",
+                               (int)entry->tileId, (int)w, (int)h,
+                               (int)tiles[entry->tileId].dim.width,
+                               (int)tiles[entry->tileId].dim.height);
+                    }
+                }
+            }
+        }
+        else
+        {
+            failCount++;
+            if (logBudget > 0)
+            {
+                logBudget--;
+                printf("loadpics: override metadata failed for tile %d file '%s'\n",
+                       (int)entry->tileId, entry->fileName);
+            }
+        }
+    }
+
+    printf("loadpics: override metadata primed from PNG headers: new=%" PRId32 ", fail=%" PRId32 ", size-mismatch=%" PRId32 "\n",
+           okCount, failCount, mismatchCount);
+}
+
+static void init_override_palette_cache(void)
+{
+    int i;
+    for (i = 0; i < OVERRIDE_PAL_CACHE_SLOTS; i++)
+        overridePalCacheKey[i] = 0xffffffffu;
+    overridePalCacheInit = 1;
+}
+
 static uint8_t nearest_palette_index(uint8_t r, uint8_t g, uint8_t b)
 {
     int bestIdx = 0;
@@ -312,6 +434,22 @@ static uint8_t nearest_palette_index(uint8_t r, uint8_t g, uint8_t b)
     return (uint8_t)bestIdx;
 }
 
+static uint8_t nearest_palette_index_cached(uint8_t r, uint8_t g, uint8_t b)
+{
+    const uint32_t key = ((uint32_t)r << 16) | ((uint32_t)g << 8) | (uint32_t)b;
+    const uint32_t slot = (key * 2654435761u) >> (32 - 12);
+
+    if (!overridePalCacheInit)
+        init_override_palette_cache();
+
+    if (overridePalCacheKey[slot] == key)
+        return overridePalCacheValue[slot];
+
+    overridePalCacheKey[slot] = key;
+    overridePalCacheValue[slot] = nearest_palette_index(r, g, b);
+    return overridePalCacheValue[slot];
+}
+
 static int try_loadtile_from_override_png(short tilenume)
 {
     int32_t fileHandle;
@@ -324,6 +462,8 @@ static int try_loadtile_from_override_png(short tilenume)
     uint8_t *dst;
     int32_t pixelCount;
     int32_t x, y;
+    int32_t targetWidth;
+    int32_t targetHeight;
 
     const char *overrideFile;
 
@@ -333,6 +473,9 @@ static int try_loadtile_from_override_png(short tilenume)
     overrideFile = get_tile_override_file(tilenume);
     if (!overrideFile)
         return 0;
+
+    if (tiles[tilenume].data != NULL)
+        return 1;
 
     fileHandle = TCkopen4load(overrideFile, 0);
     if (fileHandle == -1)
@@ -372,20 +515,41 @@ static int try_loadtile_from_override_png(short tilenume)
         return 0;
     }
 
-    tiles[tilenume].dim.width = (short)width;
-    tiles[tilenume].dim.height = (short)height;
+    targetWidth = (tiles[tilenume].dim.width > 0) ? (int32_t)tiles[tilenume].dim.width : (int32_t)width;
+    targetHeight = (tiles[tilenume].dim.height > 0) ? (int32_t)tiles[tilenume].dim.height : (int32_t)height;
 
-    pixelCount = (int32_t)(width * height);
+    if ((targetWidth <= 0) || (targetHeight <= 0) ||
+        ((int64_t)targetWidth * (int64_t)targetHeight > 0x7fffffffLL))
+    {
+        free(rgba);
+        return 0;
+    }
+
+    if ((targetWidth != (int32_t)width) || (targetHeight != (int32_t)height))
+    {
+        static int overrideSizeWarnBudget = 128;
+        if (overrideSizeWarnBudget > 0)
+        {
+            overrideSizeWarnBudget--;
+            printf("loadtile: tile %d override '%s' PNG=%ux%u, using metadata size=%" PRId32 "x%" PRId32 " (scaled)\n",
+                   (int)tilenume, overrideFile, width, height, targetWidth, targetHeight);
+        }
+    }
+
+    tiles[tilenume].dim.width = (short)targetWidth;
+    tiles[tilenume].dim.height = (short)targetHeight;
+
+    pixelCount = targetWidth * targetHeight;
 
     {
         int j;
         j = 15;
-        while ((j > 1) && (pow2long[j] > (int32_t)width))
+        while ((j > 1) && (pow2long[j] > targetWidth))
             j--;
         picsiz[tilenume] = (uint8_t)j;
 
         j = 15;
-        while ((j > 1) && (pow2long[j] > (int32_t)height))
+        while ((j > 1) && (pow2long[j] > targetHeight))
             j--;
         picsiz[tilenume] += (uint8_t)(j << 4);
     }
@@ -402,17 +566,29 @@ static int try_loadtile_from_override_png(short tilenume)
     }
 
     dst = tiles[tilenume].data;
-    for (y = 0; y < (int32_t)height; y++)
+    for (y = 0; y < targetHeight; y++)
     {
-        for (x = 0; x < (int32_t)width; x++)
+        for (x = 0; x < targetWidth; x++)
         {
-            const int32_t srcIndex = (y * (int32_t)width + x) * 4;
-            const int32_t dstIndex = x * (int32_t)height + y;
+            const int32_t srcX = (x * (int32_t)width) / targetWidth;
+            const int32_t srcY = (y * (int32_t)height) / targetHeight;
+            const int32_t srcIndex = (srcY * (int32_t)width + srcX) * 4;
+            const int32_t dstIndex = x * targetHeight + y;
             const uint8_t r = rgba[srcIndex + 0];
             const uint8_t g = rgba[srcIndex + 1];
             const uint8_t b = rgba[srcIndex + 2];
             const uint8_t a = rgba[srcIndex + 3];
-            dst[dstIndex] = (a < 128) ? 255 : nearest_palette_index(r, g, b);
+            dst[dstIndex] = (a < 128) ? 255 : nearest_palette_index_cached(r, g, b);
+        }
+    }
+
+    {
+        static int overrideDecodeLogBudget = 128;
+        if (overrideDecodeLogBudget > 0)
+        {
+            overrideDecodeLogBudget--;
+            printf("loadtile: decoded override tile %d from '%s' (png=%ux%u -> tile=%" PRId32 "x%" PRId32 ", %" PRId32 " px)\n",
+                   (int)tilenume, overrideFile, width, height, targetWidth, targetHeight, pixelCount);
         }
     }
 
@@ -657,6 +833,8 @@ int loadpics(char  *filename, char * gamedir)
                 if (missingStreak >= ART_MISS_STREAK_STOP)
                     break;
             }
+            if (!seenAnyArt && k >= ART_MISS_STREAK_STOP)
+                break;
             continue;
         }
 
@@ -697,8 +875,11 @@ int loadpics(char  *filename, char * gamedir)
     }
 
     printf("Art files loaded: %" PRId32 " file(s) found by sparse scan\n", numtilefiles);
+    if (!seenAnyArt)
+        printf("loadpics: no ART files found; relying on DEF PNG overrides and header metadata\n");
 
     parse_tile_overrides_from_def();
+    prime_tile_override_metadata_from_png_headers();
 
     clearbuf(gotpic,(MAXTILES+31)>>5,0L);
 

--- a/duke3d-go/components/duke3d/Engine/tiles.c
+++ b/duke3d-go/components/duke3d/Engine/tiles.c
@@ -13,6 +13,10 @@
 
 #include <rg_system.h>
 #include "esp_attr.h"
+#include <lodepng.h>
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
 
 char  artfilename[20];
 
@@ -25,6 +29,389 @@ int32_t artversion;
 uint8_t  *pic = NULL;
 
 EXT_RAM_BSS_ATTR uint8_t  gotpic[(MAXTILES+7)>>3];
+
+#define TILE_OVERRIDE_NAME_MAX 128
+
+typedef struct tile_override_s {
+    short tileId;
+    char fileName[TILE_OVERRIDE_NAME_MAX];
+    struct tile_override_s *next;
+} tile_override_t;
+
+static tile_override_t *tileOverridesHead = NULL;
+
+static int ci_starts_with(const char *s, const char *prefix)
+{
+    while (*prefix)
+    {
+        if (tolower((unsigned char)*s) != tolower((unsigned char)*prefix))
+            return 0;
+        s++;
+        prefix++;
+    }
+    return 1;
+}
+
+static void clear_tile_overrides(void)
+{
+    tile_override_t *entry = tileOverridesHead;
+    while (entry)
+    {
+        tile_override_t *next = entry->next;
+        free(entry);
+        entry = next;
+    }
+    tileOverridesHead = NULL;
+}
+
+static tile_override_t *find_tile_override(short tileId)
+{
+    tile_override_t *entry = tileOverridesHead;
+    while (entry)
+    {
+        if (entry->tileId == tileId)
+            return entry;
+        entry = entry->next;
+    }
+    return NULL;
+}
+
+static int set_tile_override(short tileId, const char *fileName)
+{
+    tile_override_t *entry;
+
+    if (!fileName || !fileName[0])
+        return 0;
+
+    entry = find_tile_override(tileId);
+    if (!entry)
+    {
+        entry = (tile_override_t *)malloc(sizeof(tile_override_t));
+        if (!entry)
+            return 0;
+        entry->tileId = tileId;
+        entry->next = tileOverridesHead;
+        tileOverridesHead = entry;
+    }
+
+    strncpy(entry->fileName, fileName, TILE_OVERRIDE_NAME_MAX - 1);
+    entry->fileName[TILE_OVERRIDE_NAME_MAX - 1] = '\0';
+    return 1;
+}
+
+static const char *get_tile_override_file(short tileId)
+{
+    tile_override_t *entry = find_tile_override(tileId);
+    return entry ? entry->fileName : NULL;
+}
+
+static int find_keyword_ci(const char *start, const char *end, const char *keyword, const char **out)
+{
+    size_t kwlen = strlen(keyword);
+    const char *p;
+
+    if ((start == NULL) || (end == NULL) || (start >= end) || (kwlen == 0))
+        return 0;
+
+    for (p = start; p + kwlen <= end; p++)
+    {
+        if ((p > start) && (isalnum((unsigned char)p[-1]) || p[-1] == '_'))
+            continue;
+
+        if (ci_starts_with(p, keyword))
+        {
+            const char after = p[kwlen];
+            if (!(isalnum((unsigned char)after) || after == '_'))
+            {
+                if (out) *out = p;
+                return 1;
+            }
+        }
+    }
+
+    return 0;
+}
+
+static int parse_file_token_from_block(const char *blockStart, const char *blockEnd, char *outName, size_t outNameSize)
+{
+    const char *kw = NULL;
+    const char *p;
+
+    if (!find_keyword_ci(blockStart, blockEnd, "file", &kw))
+        return 0;
+
+    p = kw + 4;
+    while ((p < blockEnd) && isspace((unsigned char)*p))
+        p++;
+
+    if (p >= blockEnd)
+        return 0;
+
+    if ((*p == '"') || (*p == '\''))
+    {
+        const char quote = *p++;
+        const char *start = p;
+        while ((p < blockEnd) && (*p != quote))
+            p++;
+
+        if ((p <= start) || (p > blockEnd))
+            return 0;
+
+        {
+            size_t len = (size_t)(p - start);
+            if (len >= outNameSize)
+                len = outNameSize - 1;
+            memcpy(outName, start, len);
+            outName[len] = '\0';
+            return (len > 0);
+        }
+    }
+    else
+    {
+        const char *start = p;
+        while ((p < blockEnd) && !isspace((unsigned char)*p) && (*p != '}'))
+            p++;
+
+        if (p <= start)
+            return 0;
+
+        {
+            size_t len = (size_t)(p - start);
+            if (len >= outNameSize)
+                len = outNameSize - 1;
+            memcpy(outName, start, len);
+            outName[len] = '\0';
+            return (len > 0);
+        }
+    }
+}
+
+static void parse_tile_overrides_from_def(void)
+{
+    int32_t defHandle;
+
+    clear_tile_overrides();
+
+    defHandle = kopen4load("duke3d.def", 1);
+    if (defHandle == -1)
+        return;
+
+    {
+        int32_t defSize = kfilelength(defHandle);
+        char *defText;
+        const char *scan;
+        const char *end;
+
+        if (defSize <= 0)
+        {
+            kclose(defHandle);
+            return;
+        }
+
+        defText = (char *)malloc((size_t)defSize + 1);
+        if (defText == NULL)
+        {
+            kclose(defHandle);
+            return;
+        }
+
+        if (kread(defHandle, defText, defSize) != defSize)
+        {
+            free(defText);
+            kclose(defHandle);
+            return;
+        }
+
+        defText[defSize] = '\0';
+        kclose(defHandle);
+
+        scan = defText;
+        end = defText + defSize;
+
+        while (scan < end)
+        {
+            const char *kw = NULL;
+            long tileId;
+            const char *p;
+            const char *braceOpen;
+            const char *braceClose;
+            char pngName[TILE_OVERRIDE_NAME_MAX];
+
+            if (!find_keyword_ci(scan, end, "tilefromtexture", &kw))
+                break;
+
+            p = kw + strlen("tilefromtexture");
+            while ((p < end) && isspace((unsigned char)*p))
+                p++;
+
+            if (p >= end)
+                break;
+
+            tileId = strtol(p, (char **)&p, 10);
+
+            if ((tileId < 0) || (tileId >= MAXTILES))
+            {
+                scan = kw + 1;
+                continue;
+            }
+
+            while ((p < end) && (*p != '{'))
+                p++;
+
+            if ((p >= end) || (*p != '{'))
+            {
+                scan = kw + 1;
+                continue;
+            }
+
+            braceOpen = p + 1;
+            braceClose = braceOpen;
+            while ((braceClose < end) && (*braceClose != '}'))
+                braceClose++;
+
+            if (braceClose >= end)
+                break;
+
+            if (parse_file_token_from_block(braceOpen, braceClose, pngName, sizeof(pngName)))
+                set_tile_override((short)tileId, pngName);
+
+            scan = braceClose + 1;
+        }
+
+        free(defText);
+    }
+}
+
+static uint8_t nearest_palette_index(uint8_t r, uint8_t g, uint8_t b)
+{
+    int bestIdx = 0;
+    int bestDist = 0x7fffffff;
+    int i;
+
+    for (i = 0; i < 256; i++)
+    {
+        const int pr = palette[i * 3 + 0] << 2;
+        const int pg = palette[i * 3 + 1] << 2;
+        const int pb = palette[i * 3 + 2] << 2;
+        const int dr = (int)r - pr;
+        const int dg = (int)g - pg;
+        const int db = (int)b - pb;
+        const int dist = dr * dr + dg * dg + db * db;
+
+        if (dist < bestDist)
+        {
+            bestDist = dist;
+            bestIdx = i;
+            if (dist == 0)
+                break;
+        }
+    }
+
+    return (uint8_t)bestIdx;
+}
+
+static int try_loadtile_from_override_png(short tilenume)
+{
+    int32_t fileHandle;
+    int32_t fileSize;
+    uint8_t *pngBytes = NULL;
+    unsigned char *rgba = NULL;
+    unsigned width = 0;
+    unsigned height = 0;
+    unsigned err;
+    uint8_t *dst;
+    int32_t pixelCount;
+    int32_t i;
+
+    const char *overrideFile;
+
+    if ((tilenume < 0) || (tilenume >= MAXTILES))
+        return 0;
+
+    overrideFile = get_tile_override_file(tilenume);
+    if (!overrideFile)
+        return 0;
+
+    fileHandle = TCkopen4load(overrideFile, 0);
+    if (fileHandle == -1)
+        return 0;
+
+    fileSize = kfilelength(fileHandle);
+    if (fileSize <= 0)
+    {
+        kclose(fileHandle);
+        return 0;
+    }
+
+    pngBytes = (uint8_t *)malloc((size_t)fileSize);
+    if (pngBytes == NULL)
+    {
+        kclose(fileHandle);
+        return 0;
+    }
+
+    if (kread(fileHandle, pngBytes, fileSize) != fileSize)
+    {
+        free(pngBytes);
+        kclose(fileHandle);
+        return 0;
+    }
+    kclose(fileHandle);
+
+    err = lodepng_decode32(&rgba, &width, &height, pngBytes, (size_t)fileSize);
+    free(pngBytes);
+    if (err != 0 || rgba == NULL)
+        return 0;
+
+    if ((width == 0) || (height == 0) || (width > 32767) || (height > 32767) ||
+        ((uint64_t)width * (uint64_t)height > 0x7fffffffULL))
+    {
+        free(rgba);
+        return 0;
+    }
+
+    tiles[tilenume].dim.width = (short)width;
+    tiles[tilenume].dim.height = (short)height;
+
+    pixelCount = (int32_t)(width * height);
+
+    {
+        int j;
+        j = 15;
+        while ((j > 1) && (pow2long[j] > (int32_t)width))
+            j--;
+        picsiz[tilenume] = (uint8_t)j;
+
+        j = 15;
+        while ((j > 1) && (pow2long[j] > (int32_t)height))
+            j--;
+        picsiz[tilenume] += (uint8_t)(j << 4);
+    }
+
+    if (tiles[tilenume].data == NULL)
+    {
+        tiles[tilenume].lock = 199;
+        allocache(&tiles[tilenume].data, pixelCount, (uint8_t *)&tiles[tilenume].lock);
+        if (tiles[tilenume].data == NULL)
+        {
+            free(rgba);
+            return 0;
+        }
+    }
+
+    dst = tiles[tilenume].data;
+    for (i = 0; i < pixelCount; i++)
+    {
+        const uint8_t r = rgba[i * 4 + 0];
+        const uint8_t g = rgba[i * 4 + 1];
+        const uint8_t b = rgba[i * 4 + 2];
+        const uint8_t a = rgba[i * 4 + 3];
+        dst[i] = (a < 128) ? 255 : nearest_palette_index(r, g, b);
+    }
+
+    free(rgba);
+    return 1;
+}
 
 void setviewtotile(short tilenume, int32_t tileWidth, int32_t tileHeight)
 {
@@ -117,6 +504,9 @@ void loadtile(short tilenume)
 
 
     if ((uint32_t)tilenume >= (uint32_t)MAXTILES)
+        return;
+
+    if (try_loadtile_from_override_png(tilenume))
         return;
 
     tileFilesize = tiles[tilenume].dim.width * tiles[tilenume].dim.height;
@@ -278,6 +668,8 @@ int loadpics(char  *filename, char * gamedir)
     while (k != numtilefiles);
 
     RG_LOGD("Art files loaded");
+
+    parse_tile_overrides_from_def();
 
     clearbuf(gotpic,(MAXTILES+31)>>5,0L);
 

--- a/duke3d-go/components/duke3d/Engine/tiles.c
+++ b/duke3d-go/components/duke3d/Engine/tiles.c
@@ -195,6 +195,53 @@ static int parse_file_token_from_block(const char *blockStart, const char *block
     }
 }
 
+static int parse_int_token_from_block(const char *blockStart, const char *blockEnd, const char *token, long *outValue)
+{
+    const char *kw = NULL;
+    const char *p;
+    const char *parseStart;
+    long value;
+
+    if (!outValue)
+        return 0;
+
+    if (!find_keyword_ci(blockStart, blockEnd, token, &kw))
+        return 0;
+
+    p = kw + strlen(token);
+    while ((p < blockEnd) && isspace((unsigned char)*p))
+        p++;
+
+    parseStart = p;
+    value = strtol(p, (char **)&p, 10);
+    if (p == parseStart)
+        return 0;
+
+    *outValue = value;
+    return 1;
+}
+
+static void set_tile_offsets(short tileId, long xoffset, long yoffset)
+{
+    uint32_t flags;
+    int32_t xofs8 = (int32_t)xoffset;
+    int32_t yofs8 = (int32_t)yoffset;
+
+    if ((tileId < 0) || (tileId >= MAXTILES))
+        return;
+
+    if (xofs8 < -128) xofs8 = -128;
+    if (xofs8 > 127) xofs8 = 127;
+    if (yofs8 < -128) yofs8 = -128;
+    if (yofs8 > 127) yofs8 = 127;
+
+    flags = (uint32_t)tiles[tileId].animFlags;
+    flags &= 0xFF0000FFu;
+    flags |= ((uint32_t)((uint8_t)(int8_t)xofs8) << 8);
+    flags |= ((uint32_t)((uint8_t)(int8_t)yofs8) << 16);
+    tiles[tileId].animFlags = (int32_t)flags;
+}
+
 static void apply_animtilerange_to_tiles(long startTile, long endTile, long speed, long animation)
 {
     long i;
@@ -272,6 +319,10 @@ static void parse_tile_overrides_from_def(void)
             const char *braceOpen;
             const char *braceClose;
             char pngName[TILE_OVERRIDE_NAME_MAX];
+            long parsedXoff = 0;
+            long parsedYoff = 0;
+            int hasXoff = 0;
+            int hasYoff = 0;
 
             if (!find_keyword_ci(scan, end, "tilefromtexture", &kw))
                 break;
@@ -310,6 +361,25 @@ static void parse_tile_overrides_from_def(void)
 
             if (parse_file_token_from_block(braceOpen, braceClose, pngName, sizeof(pngName)))
                 set_tile_override((short)tileId, pngName);
+
+            hasXoff = parse_int_token_from_block(braceOpen, braceClose, "xoffset", &parsedXoff);
+            hasYoff = parse_int_token_from_block(braceOpen, braceClose, "yoffset", &parsedYoff);
+            if (hasXoff || hasYoff)
+            {
+                const int32_t currentXoff = (int32_t)(int8_t)((tiles[tileId].animFlags >> 8) & 255);
+                const int32_t currentYoff = (int32_t)(int8_t)((tiles[tileId].animFlags >> 16) & 255);
+                const long finalXoff = hasXoff ? parsedXoff : currentXoff;
+                const long finalYoff = hasYoff ? parsedYoff : currentYoff;
+                set_tile_offsets((short)tileId, finalXoff, finalYoff);
+
+                if (tileId == 2544)
+                {
+                    printf("tilefromtexture: tile 2544 parsed offsets x=%ld y=%ld (raw x token=%s y token=%s)\n",
+                           finalXoff, finalYoff,
+                           hasXoff ? "present" : "missing",
+                           hasYoff ? "present" : "missing");
+                }
+            }
 
             scan = braceClose + 1;
         }

--- a/duke3d-go/components/duke3d/Engine/tiles.c
+++ b/duke3d-go/components/duke3d/Engine/tiles.c
@@ -31,6 +31,8 @@ uint8_t  *pic = NULL;
 EXT_RAM_BSS_ATTR uint8_t  gotpic[(MAXTILES+7)>>3];
 
 #define TILE_OVERRIDE_NAME_MAX 128
+#define MAX_ART_FILES_SCAN 1000
+#define ART_MISS_STREAK_STOP 32
 
 typedef struct tile_override_s {
     short tileId;
@@ -517,7 +519,19 @@ void loadtile(short tilenume)
     tileFilesize = tiles[tilenume].dim.width * tiles[tilenume].dim.height;
 
     if (tileFilesize <= 0)
+    {
+        static int missingTileWarnBudget = 64;
+        if (missingTileWarnBudget > 0)
+        {
+            missingTileWarnBudget--;
+            printf("loadtile: tile %d has invalid size %" PRId32 " (w=%d h=%d, artfile=%d).\n",
+                   (int)tilenume, tileFilesize,
+                   (int)tiles[tilenume].dim.width,
+                   (int)tiles[tilenume].dim.height,
+                   (int)tilefilenum[tilenume]);
+        }
         return;
+    }
 
     i = tilefilenum[tilenume];
     if (i != artfilnum){
@@ -608,7 +622,10 @@ int loadpics(char  *filename, char * gamedir)
 
 {
     int32_t offscount, localtilestart, localtileend, dasiz;
-    short fil, i, j, k;
+    short fil, i, j;
+    int32_t k;
+    int32_t missingStreak = 0;
+    int32_t seenAnyArt = 0;
 
 
     strcpy(artfilename,filename);
@@ -623,56 +640,63 @@ int loadpics(char  *filename, char * gamedir)
     artsize = 0L;
 
     numtilefiles = 0;
-    do
+    for (k = 0; k < MAX_ART_FILES_SCAN; k++)
     {
-        k = numtilefiles;
-
         artfilename[7] = (k%10)+48;
         artfilename[6] = ((k/10)%10)+48;
         artfilename[5] = ((k/100)%10)+48;
 
-
-
-        if ((fil = TCkopen4load(artfilename,0)) != -1)
+        fil = TCkopen4load(artfilename,0);
+        if (fil == -1)
         {
-            RG_LOGD("loadpics: Loading '%s'...", artfilename);
-            kread32(fil,&artversion);
-            if (artversion != 1) return(-1);
-
-            kread32(fil,&numTiles);
-            kread32(fil,&localtilestart);
-            kread32(fil,&localtileend);
-
-            /*kread(fil,&tilesizx[localtilestart],(localtileend-localtilestart+1)<<1);*/
-            for (i = localtilestart; i <= localtileend; i++)
-                kread16(fil,&tiles[i].dim.width);
-
-            /*kread(fil,&tilesizy[localtilestart],(localtileend-localtilestart+1)<<1);*/
-            for (i = localtilestart; i <= localtileend; i++)
-                kread16(fil,&tiles[i].dim.height);
-
-            /*kread(fil,&picanm[localtilestart],(localtileend-localtilestart+1)<<2);*/
-            for (i = localtilestart; i <= localtileend; i++)
-                kread32(fil,&tiles[i].animFlags);
-
-            offscount = 4+4+4+4+((localtileend-localtilestart+1)<<3);
-            for(i=localtilestart; i<=localtileend; i++)
+            if (seenAnyArt)
             {
-                tilefilenum[i] = k;
-                tilefileoffs[i] = offscount;
-                dasiz = tiles[i].dim.width*tiles[i].dim.height;
-                offscount += dasiz;
-                artsize += ((dasiz+15)&0xfffffff0);
+                missingStreak++;
+                if (missingStreak == 1)
+                    printf("loadpics: missing '%s', continuing scan for sparse ART sets...\n", artfilename);
+                if (missingStreak >= ART_MISS_STREAK_STOP)
+                    break;
             }
-            kclose(fil);
-
-            numtilefiles++;
-
+            continue;
         }
-    }
-    while (k != numtilefiles);
 
-    RG_LOGD("Art files loaded");
+        seenAnyArt = 1;
+        missingStreak = 0;
+        printf("loadpics: Loading '%s'...\n", artfilename);
+        kread32(fil,&artversion);
+        if (artversion != 1) return(-1);
+
+        kread32(fil,&numTiles);
+        kread32(fil,&localtilestart);
+        kread32(fil,&localtileend);
+
+        /*kread(fil,&tilesizx[localtilestart],(localtileend-localtilestart+1)<<1);*/
+        for (i = localtilestart; i <= localtileend; i++)
+            kread16(fil,&tiles[i].dim.width);
+
+        /*kread(fil,&tilesizy[localtilestart],(localtileend-localtilestart+1)<<1);*/
+        for (i = localtilestart; i <= localtileend; i++)
+            kread16(fil,&tiles[i].dim.height);
+
+        /*kread(fil,&picanm[localtilestart],(localtileend-localtilestart+1)<<2);*/
+        for (i = localtilestart; i <= localtileend; i++)
+            kread32(fil,&tiles[i].animFlags);
+
+        offscount = 4+4+4+4+((localtileend-localtilestart+1)<<3);
+        for(i=localtilestart; i<=localtileend; i++)
+        {
+            tilefilenum[i] = (short)k;
+            tilefileoffs[i] = offscount;
+            dasiz = tiles[i].dim.width*tiles[i].dim.height;
+            offscount += dasiz;
+            artsize += ((dasiz+15)&0xfffffff0);
+        }
+        kclose(fil);
+
+        numtilefiles++;
+    }
+
+    printf("Art files loaded: %" PRId32 " file(s) found by sparse scan\n", numtilefiles);
 
     parse_tile_overrides_from_def();
 

--- a/duke3d-go/components/duke3d/Engine/tiles.c
+++ b/duke3d-go/components/duke3d/Engine/tiles.c
@@ -194,6 +194,33 @@ static int parse_file_token_from_block(const char *blockStart, const char *block
     }
 }
 
+static void apply_animtilerange_to_tiles(long startTile, long endTile, long speed, long animation)
+{
+    long i;
+    int32_t frameCount;
+    uint32_t animTypeBits;
+    uint32_t speedBits;
+
+    if ((startTile < 0) || (endTile < startTile) || (endTile >= MAXTILES))
+        return;
+
+    if ((speed < 0) || (speed > 15) || (animation < 0) || (animation > 3))
+        return;
+
+    frameCount = (int32_t)(endTile - startTile);
+    if (frameCount > 63)
+        frameCount = 63;
+
+    animTypeBits = ((uint32_t)animation & 3u) << 6;
+    speedBits = ((uint32_t)speed & 15u) << 24;
+
+    for (i = startTile; i <= endTile; i++)
+    {
+        uint32_t baseFlags = ((uint32_t)tiles[i].animFlags) & 0xF0FFFF00u;
+        tiles[i].animFlags = (int32_t)(baseFlags | (uint32_t)frameCount | animTypeBits | speedBits);
+    }
+}
+
 static void parse_tile_overrides_from_def(void)
 {
     int32_t defHandle;
@@ -284,6 +311,66 @@ static void parse_tile_overrides_from_def(void)
                 set_tile_override((short)tileId, pngName);
 
             scan = braceClose + 1;
+        }
+
+        scan = defText;
+        while (scan < end)
+        {
+            const char *kw = NULL;
+            const char *p;
+            const char *parseStart;
+            long startTile;
+            long endTile;
+            long speed;
+            long animation;
+
+            if (!find_keyword_ci(scan, end, "animtilerange", &kw))
+                break;
+
+            p = kw + strlen("animtilerange");
+
+            while ((p < end) && isspace((unsigned char)*p))
+                p++;
+            parseStart = p;
+            startTile = strtol(p, (char **)&p, 10);
+            if (p == parseStart)
+            {
+                scan = kw + 1;
+                continue;
+            }
+
+            while ((p < end) && isspace((unsigned char)*p))
+                p++;
+            parseStart = p;
+            endTile = strtol(p, (char **)&p, 10);
+            if (p == parseStart)
+            {
+                scan = kw + 1;
+                continue;
+            }
+
+            while ((p < end) && isspace((unsigned char)*p))
+                p++;
+            parseStart = p;
+            speed = strtol(p, (char **)&p, 10);
+            if (p == parseStart)
+            {
+                scan = kw + 1;
+                continue;
+            }
+
+            while ((p < end) && isspace((unsigned char)*p))
+                p++;
+            parseStart = p;
+            animation = strtol(p, (char **)&p, 10);
+            if (p == parseStart)
+            {
+                scan = kw + 1;
+                continue;
+            }
+
+            apply_animtilerange_to_tiles(startTile, endTile, speed, animation);
+            scan = p;
         }
 
         free(defText);

--- a/duke3d-go/components/duke3d/Game/game.c
+++ b/duke3d-go/components/duke3d/Game/game.c
@@ -116,7 +116,6 @@ uint8_t  debug_on = 0,actor_tog = 0,memorycheckoveride=0;
 uint8_t *rtsptr;
 
 static volatile bool engine_exit_requested = false;
-static char g_unzipped_grp_path[512] = {0};
 
 bool rg_system_should_exit(void)
 {
@@ -2508,12 +2507,6 @@ void gameexit(char  *msg)
     }
 
     uninitgroupfile();
-
-    if (g_unzipped_grp_path[0] != '\0')
-    {
-        unlink(g_unzipped_grp_path);
-        g_unzipped_grp_path[0] = '\0';
-    }
 
     unlink("duke3d.tmp");
 
@@ -8118,29 +8111,6 @@ void findGRPToUse(char * groupfilefullpath){
 
     if (app && app->romPath && app->romPath[0] != '\0')
     {
-        if (rg_extension_match(app->romPath, "zip"))
-        {
-            void *grp_data = NULL;
-            size_t grp_size = 0;
-
-            if (!rg_storage_unzip_file(app->romPath, NULL, &grp_data, &grp_size, 0))
-            {
-                Error(EXIT_SUCCESS, "Unable to unzip ROM archive: %s\n", app->romPath);
-            }
-
-            snprintf(g_unzipped_grp_path, sizeof(g_unzipped_grp_path), "%s/duke3d.rom.grp", RG_BASE_PATH_CACHE);
-            if (!rg_storage_write_file(g_unzipped_grp_path, grp_data, grp_size, RG_FILE_ATOMIC_WRITE))
-            {
-                free(grp_data);
-                Error(EXIT_SUCCESS, "Unable to write temporary GRP file: %s\n", g_unzipped_grp_path);
-            }
-
-            free(grp_data);
-            snprintf(groupfilefullpath, 512, "%s", g_unzipped_grp_path);
-            RG_LOGI("Using Duke3D GRP extracted from ZIP: %s -> %s", app->romPath, groupfilefullpath);
-            return;
-        }
-
         snprintf(groupfilefullpath, 512, "%s", app->romPath);
         RG_LOGI("Using Duke3D GRP from boot config: %s", groupfilefullpath);
         return;
@@ -8157,14 +8127,33 @@ static int load_duke3d_groupfile(void)
 	// FIX_00032: Added multi base GRP manager. Use duke3d*.grp to handle multiple grp.
 
 	char  groupfilefullpath[512];
-    groupfilefullpath[0] = '\0';
+	   groupfilefullpath[0] = '\0';
+	   const rg_app_t *app = rg_system_get_app();
 
-    findGRPToUse(groupfilefullpath);
+	   if (app && app->romPath && app->romPath[0] != '\0' && rg_extension_match(app->romPath, "zip"))
+	   {
+	       void *grp_data = NULL;
+	       size_t grp_size = 0;
 
-    if (groupfilefullpath[0] == '\0')
-    {
-        return false;
-    }
+	       if (!rg_storage_unzip_file(app->romPath, NULL, &grp_data, &grp_size, 0))
+	           Error(EXIT_SUCCESS, "Unable to unzip ROM archive: %s\n", app->romPath);
+
+	       if (initgroupfile_from_memory(app->romPath, grp_data, (int32_t)grp_size) == -1)
+	       {
+	           free(grp_data);
+	           Error(EXIT_SUCCESS, "Unable to initialize GRP from ZIP ROM: %s\n", app->romPath);
+	       }
+
+	       RG_LOGI("Using Duke3D GRP extracted to RAM from ZIP: %s", app->romPath);
+	       return true;
+	   }
+
+	   findGRPToUse(groupfilefullpath);
+
+	   if (groupfilefullpath[0] == '\0')
+	   {
+	       return false;
+	   }
 
 	FixFilePath(groupfilefullpath);
 

--- a/duke3d-go/components/duke3d/Game/game.c
+++ b/duke3d-go/components/duke3d/Game/game.c
@@ -8366,34 +8366,35 @@ static int load_duke3d_groupfile(void)
 {
 	// FIX_00032: Added multi base GRP manager. Use duke3d*.grp to handle multiple grp.
 
-	char  groupfilefullpath[512];
-	   groupfilefullpath[0] = '\0';
-	   const rg_app_t *app = rg_system_get_app();
+	char groupfilefullpath[512];
+	const rg_app_t *app = rg_system_get_app();
 
-	   if (app && app->romPath && app->romPath[0] != '\0' && rg_extension_match(app->romPath, "zip"))
-	   {
-	       void *grp_data = NULL;
-	       size_t grp_size = 0;
+	if (app && app->romPath && app->romPath[0] != '\0' && rg_extension_match(app->romPath, "zip"))
+	{
+		void *grp_data = NULL;
+		size_t grp_size = 0;
 
-	       if (!rg_storage_unzip_file(app->romPath, NULL, &grp_data, &grp_size, 0))
-	           Error(EXIT_SUCCESS, "Unable to unzip ROM archive: %s\n", app->romPath);
+		if (!rg_storage_unzip_file(app->romPath, NULL, &grp_data, &grp_size, 0))
+			Error(EXIT_SUCCESS, "Unable to unzip ROM archive: %s\n", app->romPath);
 
-	       if (initgroupfile_from_memory(app->romPath, grp_data, (int32_t)grp_size) == -1)
-	       {
-	           free(grp_data);
-	           Error(EXIT_SUCCESS, "Unable to initialize GRP from ZIP ROM: %s\n", app->romPath);
-	       }
+		if (initgroupfile_from_memory(app->romPath, grp_data, (int32_t)grp_size) == -1)
+		{
+			free(grp_data);
+			Error(EXIT_SUCCESS, "Unable to initialize GRP from ZIP ROM: %s\n", app->romPath);
+		}
 
-	       RG_LOGI("Using Duke3D GRP extracted to RAM from ZIP: %s", app->romPath);
-	       return true;
-	   }
+		RG_LOGI("Using Duke3D GRP extracted to RAM from ZIP: %s", app->romPath);
+		return true;
+	}
 
-	   findGRPToUse(groupfilefullpath);
+	groupfilefullpath[0] = '\0';
 
-	   if (groupfilefullpath[0] == '\0')
-	   {
-	       return false;
-	   }
+	findGRPToUse(groupfilefullpath);
+
+	if (groupfilefullpath[0] == '\0')
+	{
+		return false;
+	}
 
 	FixFilePath(groupfilefullpath);
 

--- a/duke3d-go/components/duke3d/Game/game.c
+++ b/duke3d-go/components/duke3d/Game/game.c
@@ -46,6 +46,9 @@ Prepared for public release: 03/21/2003 - Charlie Wiederhold, 3D Realms
 
 #include "duke3d.h"
 #include <inttypes.h>
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
 #include "music.h"
 #include "rg_system.h"
 #include "rg_storage.h"
@@ -7756,6 +7759,242 @@ void ShutDown( void )
 ===================
 */
 
+static int def_ci_starts_with(const char *s, const char *prefix)
+{
+    while (*prefix)
+    {
+        if (tolower((unsigned char)*s) != tolower((unsigned char)*prefix))
+            return 0;
+        s++;
+        prefix++;
+    }
+    return 1;
+}
+
+static int def_find_keyword_ci(const char *start, const char *end, const char *keyword, const char **out)
+{
+    size_t kwlen = strlen(keyword);
+    const char *p;
+
+    if ((start == NULL) || (end == NULL) || (start >= end) || (kwlen == 0))
+        return 0;
+
+    for (p = start; p + kwlen <= end; p++)
+    {
+        if ((p > start) && (isalnum((unsigned char)p[-1]) || p[-1] == '_'))
+            continue;
+
+        if (def_ci_starts_with(p, keyword))
+        {
+            const char after = p[kwlen];
+            if (!(isalnum((unsigned char)after) || after == '_'))
+            {
+                if (out) *out = p;
+                return 1;
+            }
+        }
+    }
+
+    return 0;
+}
+
+static int def_parse_string_value(const char *blockStart, const char *blockEnd, const char *key, char *out, size_t outSize)
+{
+    const char *kw = NULL;
+    const char *p;
+
+    if (!def_find_keyword_ci(blockStart, blockEnd, key, &kw))
+        return 0;
+
+    p = kw + strlen(key);
+    while ((p < blockEnd) && isspace((unsigned char)*p))
+        p++;
+
+    if (p >= blockEnd)
+        return 0;
+
+    if ((*p == '"') || (*p == '\''))
+    {
+        const char quote = *p++;
+        const char *start = p;
+        while ((p < blockEnd) && (*p != quote))
+            p++;
+        if (p <= start)
+            return 0;
+
+        {
+            size_t len = (size_t)(p - start);
+            if (len >= outSize)
+                len = outSize - 1;
+            memcpy(out, start, len);
+            out[len] = '\0';
+            return (len > 0);
+        }
+    }
+    else
+    {
+        const char *start = p;
+        while ((p < blockEnd) && !isspace((unsigned char)*p) && (*p != '}'))
+            p++;
+        if (p <= start)
+            return 0;
+
+        {
+            size_t len = (size_t)(p - start);
+            if (len >= outSize)
+                len = outSize - 1;
+            memcpy(out, start, len);
+            out[len] = '\0';
+            return (len > 0);
+        }
+    }
+}
+
+static int def_parse_int_value(const char *blockStart, const char *blockEnd, const char *key, int *out)
+{
+    const char *kw = NULL;
+    const char *p;
+    char *endp;
+    long v;
+
+    if (!def_find_keyword_ci(blockStart, blockEnd, key, &kw))
+        return 0;
+
+    p = kw + strlen(key);
+    while ((p < blockEnd) && isspace((unsigned char)*p))
+        p++;
+
+    if (p >= blockEnd)
+        return 0;
+
+    v = strtol(p, &endp, 10);
+    if (endp == p)
+        return 0;
+
+    *out = (int)v;
+    return 1;
+}
+
+static void apply_sound_overrides_from_def(void)
+{
+    int32_t defHandle;
+
+    defHandle = kopen4load("duke3d.def", 1);
+    if (defHandle == -1)
+        return;
+
+    {
+        int32_t defSize = kfilelength(defHandle);
+        char *defText;
+        const char *scan;
+        const char *end;
+        int overrideCount = 0;
+
+        if (defSize <= 0)
+        {
+            kclose(defHandle);
+            return;
+        }
+
+        defText = (char *)malloc((size_t)defSize + 1);
+        if (defText == NULL)
+        {
+            kclose(defHandle);
+            return;
+        }
+
+        if (kread(defHandle, defText, defSize) != defSize)
+        {
+            free(defText);
+            kclose(defHandle);
+            return;
+        }
+
+        defText[defSize] = '\0';
+        kclose(defHandle);
+
+        scan = defText;
+        end = defText + defSize;
+
+        while (scan < end)
+        {
+            const char *kw = NULL;
+            const char *p;
+            const char *braceOpen;
+            const char *braceClose;
+            int soundId;
+            char soundFile[14];
+            int minpitch;
+            int maxpitch;
+            int priority;
+            int type;
+            int distance;
+
+            if (!def_find_keyword_ci(scan, end, "sound", &kw))
+                break;
+
+            p = kw + strlen("sound");
+            while ((p < end) && isspace((unsigned char)*p))
+                p++;
+
+            if ((p >= end) || (*p != '{'))
+            {
+                scan = kw + 1;
+                continue;
+            }
+
+            braceOpen = p + 1;
+            braceClose = braceOpen;
+            while ((braceClose < end) && (*braceClose != '}'))
+                braceClose++;
+
+            if (braceClose >= end)
+                break;
+
+            if (!def_parse_int_value(braceOpen, braceClose, "id", &soundId) ||
+                (soundId < 0) || (soundId >= NUM_SOUNDS))
+            {
+                scan = braceClose + 1;
+                continue;
+            }
+
+            if (def_parse_string_value(braceOpen, braceClose, "file", soundFile, sizeof(soundFile)))
+            {
+                strncpy(sounds[soundId], soundFile, sizeof(sounds[soundId]) - 1);
+                sounds[soundId][sizeof(sounds[soundId]) - 1] = '\0';
+            }
+
+            if (def_parse_int_value(braceOpen, braceClose, "minpitch", &minpitch))
+                soundps[soundId] = (short)minpitch;
+            if (def_parse_int_value(braceOpen, braceClose, "maxpitch", &maxpitch))
+                soundpe[soundId] = (short)maxpitch;
+            if (def_parse_int_value(braceOpen, braceClose, "priority", &priority))
+                soundpr[soundId] = (uint8_t)priority;
+            if (def_parse_int_value(braceOpen, braceClose, "type", &type))
+                soundm[soundId] = (uint8_t)type;
+            if (def_parse_int_value(braceOpen, braceClose, "distance", &distance))
+                soundvo[soundId] = (short)distance;
+
+            printf("duke3d.def: sound override applied id=%d file='%s' min=%d max=%d prio=%u type=%u dist=%d\n",
+                   soundId,
+                   sounds[soundId],
+                   (int)soundps[soundId],
+                   (int)soundpe[soundId],
+                   (unsigned)soundpr[soundId],
+                   (unsigned)soundm[soundId],
+                   (int)soundvo[soundId]);
+            overrideCount++;
+
+            scan = braceClose + 1;
+        }
+
+        if (overrideCount > 0)
+            printf("duke3d.def: applied %d sound override(s)\n", overrideCount);
+
+        free(defText);
+    }
+}
+
 void compilecons(void)
 {
 	char  userconfilename[512];
@@ -7767,6 +8006,7 @@ void compilecons(void)
 	sprintf(userconfilename, "%s", confilename);
 
    loadefs(userconfilename,mymembuf, 0);
+   apply_sound_overrides_from_def();
 
 }
 

--- a/duke3d-go/components/duke3d/Game/game.c
+++ b/duke3d-go/components/duke3d/Game/game.c
@@ -48,6 +48,8 @@ Prepared for public release: 03/21/2003 - Charlie Wiederhold, 3D Realms
 #include <inttypes.h>
 #include "music.h"
 #include "rg_system.h"
+#include "rg_storage.h"
+#include "rg_utils.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
@@ -114,6 +116,7 @@ uint8_t  debug_on = 0,actor_tog = 0,memorycheckoveride=0;
 uint8_t *rtsptr;
 
 static volatile bool engine_exit_requested = false;
+static char g_unzipped_grp_path[512] = {0};
 
 bool rg_system_should_exit(void)
 {
@@ -2505,6 +2508,12 @@ void gameexit(char  *msg)
     }
 
     uninitgroupfile();
+
+    if (g_unzipped_grp_path[0] != '\0')
+    {
+        unlink(g_unzipped_grp_path);
+        g_unzipped_grp_path[0] = '\0';
+    }
 
     unlink("duke3d.tmp");
 
@@ -8109,6 +8118,29 @@ void findGRPToUse(char * groupfilefullpath){
 
     if (app && app->romPath && app->romPath[0] != '\0')
     {
+        if (rg_extension_match(app->romPath, "zip"))
+        {
+            void *grp_data = NULL;
+            size_t grp_size = 0;
+
+            if (!rg_storage_unzip_file(app->romPath, NULL, &grp_data, &grp_size, 0))
+            {
+                Error(EXIT_SUCCESS, "Unable to unzip ROM archive: %s\n", app->romPath);
+            }
+
+            snprintf(g_unzipped_grp_path, sizeof(g_unzipped_grp_path), "%s/duke3d.rom.grp", RG_BASE_PATH_CACHE);
+            if (!rg_storage_write_file(g_unzipped_grp_path, grp_data, grp_size, RG_FILE_ATOMIC_WRITE))
+            {
+                free(grp_data);
+                Error(EXIT_SUCCESS, "Unable to write temporary GRP file: %s\n", g_unzipped_grp_path);
+            }
+
+            free(grp_data);
+            snprintf(groupfilefullpath, 512, "%s", g_unzipped_grp_path);
+            RG_LOGI("Using Duke3D GRP extracted from ZIP: %s -> %s", app->romPath, groupfilefullpath);
+            return;
+        }
+
         snprintf(groupfilefullpath, 512, "%s", app->romPath);
         RG_LOGI("Using Duke3D GRP from boot config: %s", groupfilefullpath);
         return;

--- a/duke3d-go/components/duke3d/Game/player.c
+++ b/duke3d-go/components/duke3d/Game/player.c
@@ -32,59 +32,6 @@ Prepared for public release: 03/21/2003 - Charlie Wiederhold, 3D Realms
 int32 turnheldtime; //MED
 int32 lastcontroltime; //MED
 
-static void debug_player_z_drift(short snum, struct player_struct *p, int32_t oldPosz, int32_t fz, int32_t cz, short psectlotag, uint32_t sb_snum, uint8_t shrunk)
-{
-    static int logBudget = 512;
-    int32_t dz;
-
-    if (snum < 0 || snum >= MAXPLAYERS)
-        return;
-
-    dz = p->posz - oldPosz;
-
-    if (logBudget > 0)
-    {
-        if (dz < -128 || dz > 128)
-        {
-            logBudget--;
-            printf("zdbg: p%d posz %" PRId32 "->%" PRId32 " dz=%" PRId32 " poszv=%" PRId32 " on_ground=%d jetpack=%d sectlotag=%d sb=0x%08" PRIx32 " fz=%" PRId32 " cz=%" PRId32 " truefz=%" PRId32 " truecz=%" PRId32 " pic=%d tile=%dx%d anim=0x%08" PRIx32 " shrunk=%d\n",
-                   (int)snum,
-                   oldPosz, p->posz, dz,
-                   p->poszv,
-                   (int)p->on_ground,
-                   (int)p->jetpack_on,
-                   (int)psectlotag,
-                   (uint32_t)sb_snum,
-                   fz, cz,
-                   p->truefz,
-                   p->truecz,
-                   (int)sprite[p->i].picnum,
-                   (int)tiles[sprite[p->i].picnum].dim.width,
-                   (int)tiles[sprite[p->i].picnum].dim.height,
-                   (uint32_t)tiles[sprite[p->i].picnum].animFlags,
-                   (int)shrunk);
-        }
-
-        if ((p->jetpack_on != 0) && ((sb_snum & 3) == 0))
-        {
-            logBudget--;
-            printf("zdbg: p%d jetpack_on=%d without vertical input sb=0x%08" PRIx32 " posz=%" PRId32 " poszv=%" PRId32 "\n",
-                   (int)snum, (int)p->jetpack_on, (uint32_t)sb_snum, p->posz, p->poszv);
-        }
-
-        if ((tiles[sprite[p->i].picnum].dim.height > 256 || tiles[sprite[p->i].picnum].dim.height <= 0) && (logBudget > 0))
-        {
-            logBudget--;
-            printf("zdbg: p%d suspicious player tile height=%d pic=%d anim=0x%08" PRIx32 "\n",
-                   (int)snum,
-                   (int)tiles[sprite[p->i].picnum].dim.height,
-                   (int)sprite[p->i].picnum,
-                   (uint32_t)tiles[sprite[p->i].picnum].animFlags);
-        }
-    }
-
-}
-
 void setpal(struct player_struct *p)
 {
     if(p->heat_on) p->palette = slimepal;
@@ -2399,7 +2346,6 @@ void checkweapons(struct player_struct *p)
 void processinput(short snum)
 {
     int32_t j, i, k, doubvel, fz, cz, hz, lz, truefdist, x, y;
-    int32_t debugStartPosz;
     uint8_t  shrunk;
     uint32_t sb_snum;
     short psect, psectlotag,*kb, tempsect, pi;
@@ -2412,7 +2358,6 @@ void processinput(short snum)
     s = &sprite[pi];
 
     kb = &p->kickback_pic;
-    debugStartPosz = p->posz;
 
     if(p->cheat_phase <= 0) sb_snum = dukeSyncArray[snum].bits;
     else sb_snum = 0;
@@ -3166,8 +3111,6 @@ void processinput(short snum)
             p->posz = cz+(4<<8);
         }
     }
-
-    debug_player_z_drift(snum, p, debugStartPosz, fz, cz, psectlotag, sb_snum, shrunk);
 
     //Do the quick lefts and rights
 

--- a/duke3d-go/components/duke3d/Game/player.c
+++ b/duke3d-go/components/duke3d/Game/player.c
@@ -32,6 +32,59 @@ Prepared for public release: 03/21/2003 - Charlie Wiederhold, 3D Realms
 int32 turnheldtime; //MED
 int32 lastcontroltime; //MED
 
+static void debug_player_z_drift(short snum, struct player_struct *p, int32_t oldPosz, int32_t fz, int32_t cz, short psectlotag, uint32_t sb_snum, uint8_t shrunk)
+{
+    static int logBudget = 512;
+    int32_t dz;
+
+    if (snum < 0 || snum >= MAXPLAYERS)
+        return;
+
+    dz = p->posz - oldPosz;
+
+    if (logBudget > 0)
+    {
+        if (dz < -128 || dz > 128)
+        {
+            logBudget--;
+            printf("zdbg: p%d posz %" PRId32 "->%" PRId32 " dz=%" PRId32 " poszv=%" PRId32 " on_ground=%d jetpack=%d sectlotag=%d sb=0x%08" PRIx32 " fz=%" PRId32 " cz=%" PRId32 " truefz=%" PRId32 " truecz=%" PRId32 " pic=%d tile=%dx%d anim=0x%08" PRIx32 " shrunk=%d\n",
+                   (int)snum,
+                   oldPosz, p->posz, dz,
+                   p->poszv,
+                   (int)p->on_ground,
+                   (int)p->jetpack_on,
+                   (int)psectlotag,
+                   (uint32_t)sb_snum,
+                   fz, cz,
+                   p->truefz,
+                   p->truecz,
+                   (int)sprite[p->i].picnum,
+                   (int)tiles[sprite[p->i].picnum].dim.width,
+                   (int)tiles[sprite[p->i].picnum].dim.height,
+                   (uint32_t)tiles[sprite[p->i].picnum].animFlags,
+                   (int)shrunk);
+        }
+
+        if ((p->jetpack_on != 0) && ((sb_snum & 3) == 0))
+        {
+            logBudget--;
+            printf("zdbg: p%d jetpack_on=%d without vertical input sb=0x%08" PRIx32 " posz=%" PRId32 " poszv=%" PRId32 "\n",
+                   (int)snum, (int)p->jetpack_on, (uint32_t)sb_snum, p->posz, p->poszv);
+        }
+
+        if ((tiles[sprite[p->i].picnum].dim.height > 256 || tiles[sprite[p->i].picnum].dim.height <= 0) && (logBudget > 0))
+        {
+            logBudget--;
+            printf("zdbg: p%d suspicious player tile height=%d pic=%d anim=0x%08" PRIx32 "\n",
+                   (int)snum,
+                   (int)tiles[sprite[p->i].picnum].dim.height,
+                   (int)sprite[p->i].picnum,
+                   (uint32_t)tiles[sprite[p->i].picnum].animFlags);
+        }
+    }
+
+}
+
 void setpal(struct player_struct *p)
 {
     if(p->heat_on) p->palette = slimepal;
@@ -2346,6 +2399,7 @@ void checkweapons(struct player_struct *p)
 void processinput(short snum)
 {
     int32_t j, i, k, doubvel, fz, cz, hz, lz, truefdist, x, y;
+    int32_t debugStartPosz;
     uint8_t  shrunk;
     uint32_t sb_snum;
     short psect, psectlotag,*kb, tempsect, pi;
@@ -2358,6 +2412,7 @@ void processinput(short snum)
     s = &sprite[pi];
 
     kb = &p->kickback_pic;
+    debugStartPosz = p->posz;
 
     if(p->cheat_phase <= 0) sb_snum = dukeSyncArray[snum].bits;
     else sb_snum = 0;
@@ -3111,6 +3166,8 @@ void processinput(short snum)
             p->posz = cz+(4<<8);
         }
     }
+
+    debug_player_z_drift(snum, p, debugStartPosz, fz, cz, psectlotag, sb_snum, shrunk);
 
     //Do the quick lefts and rights
 

--- a/launcher/main/applications.c
+++ b/launcher/main/applications.c
@@ -700,7 +700,7 @@ void applications_init(void)
     // application("Atari 2600", "a26", "a26 zip", "stella-go", 0);
     // application("Neo Geo Pocket Color", "ngp", "ngp ngc zip", "ngpocket-go", 0);
     application("DOOM", "doom", "wad zip", "prboom-go", 0);
-    application("Duke Nukem 3D", "duke3d", "grp", "duke3d-go", 0);
+    application("Duke Nukem 3D", "duke3d", "grp zip", "duke3d-go", 0);
     application("MSX", "msx", "rom mx1 mx2 dsk", "fmsx", 0);
 
     // Special app to bootstrap native esp32 binaries from the SD card


### PR DESCRIPTION
## Summary

This PR adds EDuke32-style asset override support (PNG tiles, sound definitions, ADPCM-compressed WAVs), ZIP GRP loading, and ART loading improvements to duke3d-go so that it fully supports [DukeNano3D](https://github.com/ThomasFarstrike/DukeNano3D)'s minimized .grp and .grp.zip files.

### PNG tile support
Implements `tilefromtexture` directives from `duke3d.def` so PNG files can replace individual ART-file tiles. Includes `animtilerange` support for animating those tiles. This allows shipping a stripped-down GRP with only the needed tiles as PNGs, significantly reducing storage requirements.

### ZIP GRP loading
GRP files inside `.zip` archives are now supported — the archive is extracted to memory and loaded directly via a new RAM-backed GRP initialization path, bypassing the filesystem entirely. The launcher recognizes `.zip` as a valid duke3d extension.

### Audio overrides
Adds `sound { id N file ... }` blocks from `duke3d.def` for per-sound WAV replacement. ADPCM-compressed WAVs are supported (~50% smaller than PCM), and the decoder now handles 2- and 3-bit ADPCM widths in addition to 4-bit.

### ART loading improvements
Replaced the single-pass ART file loop with a bounded sparse scan that finds non-contiguously numbered TILESNNN.ART files. Added `tileoffset` directive support. Moved large lookup tables (palette, translucency, tile metadata) to static EXTRAM to avoid depending on heap allocation order during startup.