### PR TITLE
Fix mirrors being black when using PNG textures

### DIFF
--- a/duke3d-go/components/duke3d/Engine/tiles.c
+++ b/duke3d-go/components/duke3d/Engine/tiles.c
@@ -628,6 +628,9 @@ static int try_loadtile_from_override_png(short tilenume)
     if ((tilenume < 0) || (tilenume >= MAXTILES))
         return 0;
 
+    if (tiles[tilenume].dim.width <= 0 || tiles[tilenume].dim.height <= 0)
+        return 0;
+
     overrideFile = get_tile_override_file(tilenume);
     if (!overrideFile)
         return 0;


### PR DESCRIPTION
The issue was that a mirror texture is a 10x10 image (tile 560) which is set to width = height = 0 by the original code so it's not being displayed.

But the PNG-override code was loading the PNG and re-setting the width and height to the original values, which made the image show up instead of the actual reflection that got drawn before it.

This generic fix here just checks whether a tile's width or height are zero, in which case it aborts the PNG override altogether, as that's pointless for invisible tiles.