### PR TITLE
Improve config file handling

### DIFF
--- a/duke3d-go/components/duke3d/Engine/filesystem.c
+++ b/duke3d-go/components/duke3d/Engine/filesystem.c
@@ -1025,16 +1025,7 @@ const char *get_config_path(const char *filename)
     char *dot = strrchr(name_no_ext, '.');
     if (dot && strcasecmp(dot, ".cfg") == 0) *dot = '\0';
 
-    char name_with_dir[600];
-    snprintf(name_with_dir, sizeof(name_with_dir), "duke3d/%s", name_no_ext);
-
-    char *rg_path = rg_emu_get_path(RG_PATH_GAME_CONFIG, name_with_dir);
-    if (rg_path) {
-        strncpy(path, rg_path, sizeof(path));
-        free(rg_path);
-    } else {
-        snprintf(path, sizeof(path), RG_BASE_PATH_CONFIG "/duke3d/%s", filename);
-    }
-    rg_storage_mkdir(rg_dirname(path));
+    snprintf(path, sizeof(path), RG_BASE_PATH_CONFIG "/%s.cfg", name_no_ext);
+    rg_storage_mkdir(RG_BASE_PATH_CONFIG);
     return path;
 }

--- a/duke3d-go/components/duke3d/Game/config.c
+++ b/duke3d-go/components/duke3d/Game/config.c
@@ -889,4 +889,3 @@ void CONFIG_WriteSetup( void )
        scripthandle = -1;
    }
 }
-

--- a/duke3d-go/components/duke3d/Game/global.c
+++ b/duke3d-go/components/duke3d/Game/global.c
@@ -602,15 +602,7 @@ boolean SafeFileExists ( const char  * _filename )
     strncpy(filename, _filename, sizeof (filename));
     filename[sizeof (filename) - 1] = '\0';
     FixFilePath(filename);
-    SDL_LockDisplay();
-    int ret;
-#if( defined PLATFORM_WIN32)
-    ret = access(filename, 6)      
-#else
-    ret = access(filename, F_OK);
-#endif
-    SDL_UnlockDisplay();
-    return( ret == 0);
+    return rg_storage_exists(filename);
 }
 
 
@@ -945,5 +937,3 @@ void Shutdown(void)
         shutdown_func = NULL;
     }
 }
-
-

--- a/duke3d-go/main/app_main.c
+++ b/duke3d-go/main/app_main.c
@@ -157,6 +157,7 @@ void app_main(void)
     rg_display_set_scaling(RG_DISPLAY_SCALING_FULL);
 
     ensure_dir(RG_BASE_PATH_SAVES "/duke3d");
+    ensure_dir(RG_BASE_PATH_CONFIG);
 
     RG_LOGI("app_main: Spawning Duke3D task...");
     


### PR DESCRIPTION
Set Duke3D setup config path resolution to consistently use /sd/retro-go/config/duke3d.cfg instead of legacy /sd/duke3d/duke3d file, following retro-go conventions.

Fix config existence detection by switching Duke3D SafeFileExists() to Retro-Go storage API rg_storage_exists(), preventing false "does not exist" warnings on LittleFS because that one doesn't support access() properly. 

Ensure the Retro-Go config directory exists on startup so setup/config file creation succeeds reliably.