### PR TITLE
duke3d: keep loading screen visible through cacheit/docacheit

### DIFF
--- a/duke3d-go/components/duke3d/Engine/tiles.c
+++ b/duke3d-go/components/duke3d/Engine/tiles.c
@@ -889,6 +889,8 @@ void loadtile(short tilenume)
                     (int)tiles[tilenume].dim.width,
                     (int)tiles[tilenume].dim.height);
 
+            artfilnum = -1;  // Prevent subsequent tiles from using stale -1 handle
+
             if (tiles[tilenume].data == NULL)
             {
                 tiles[tilenume].lock = 199;

--- a/duke3d-go/components/duke3d/Engine/tiles.c
+++ b/duke3d-go/components/duke3d/Engine/tiles.c
@@ -31,6 +31,7 @@ int32_t artversion;
 uint8_t  *pic = NULL;
 
 EXT_RAM_BSS_ATTR uint8_t  gotpic[(MAXTILES+7)>>3];
+EXT_RAM_BSS_ATTR static uint8_t missingPngTile[(MAXTILES+7)>>3];
 
 #define TILE_OVERRIDE_NAME_MAX 128
 #define MAX_ART_FILES_SCAN 1000
@@ -625,9 +626,19 @@ static int try_loadtile_from_override_png(short tilenume)
     int32_t targetHeight;
 
     const char *overrideFile;
+    const uint8_t missing_mask = (uint8_t)(1u << ((unsigned)tilenume & 7u));
+    const uint32_t missing_idx = (uint32_t)tilenume >> 3;
 
     if ((tilenume < 0) || (tilenume >= MAXTILES))
         return 0;
+
+    if (missingPngTile[missing_idx] & missing_mask)
+    {
+        /* Retry roughly once per second at 120 ticks/s. */
+        if ((((uint32_t)totalclock ^ (uint32_t)(uint16_t)tilenume) & 127u) != 0)
+            return 0;
+        missingPngTile[missing_idx] &= (uint8_t)~missing_mask;
+    }
 
     if (tiles[tilenume].dim.width <= 0 || tiles[tilenume].dim.height <= 0)
         return 0;
@@ -646,6 +657,7 @@ static int try_loadtile_from_override_png(short tilenume)
     fileSize = kfilelength(fileHandle);
     if (fileSize <= 0)
     {
+        missingPngTile[missing_idx] |= missing_mask;
         kclose(fileHandle);
         return 0;
     }
@@ -653,12 +665,14 @@ static int try_loadtile_from_override_png(short tilenume)
     pngBytes = (uint8_t *)malloc((size_t)fileSize);
     if (pngBytes == NULL)
     {
+        missingPngTile[missing_idx] |= missing_mask;
         kclose(fileHandle);
         return 0;
     }
 
     if (kread(fileHandle, pngBytes, fileSize) != fileSize)
     {
+        missingPngTile[missing_idx] |= missing_mask;
         free(pngBytes);
         kclose(fileHandle);
         return 0;
@@ -668,11 +682,15 @@ static int try_loadtile_from_override_png(short tilenume)
     err = lodepng_decode32(&rgba, &width, &height, pngBytes, (size_t)fileSize);
     free(pngBytes);
     if (err != 0 || rgba == NULL)
+    {
+        missingPngTile[missing_idx] |= missing_mask;
         return 0;
+    }
 
     if ((width == 0) || (height == 0) || (width > 32767) || (height > 32767) ||
         ((uint64_t)width * (uint64_t)height > 0x7fffffffULL))
     {
+        missingPngTile[missing_idx] |= missing_mask;
         free(rgba);
         return 0;
     }
@@ -683,6 +701,7 @@ static int try_loadtile_from_override_png(short tilenume)
     if ((targetWidth <= 0) || (targetHeight <= 0) ||
         ((int64_t)targetWidth * (int64_t)targetHeight > 0x7fffffffLL))
     {
+        missingPngTile[missing_idx] |= missing_mask;
         free(rgba);
         return 0;
     }
@@ -723,6 +742,7 @@ static int try_loadtile_from_override_png(short tilenume)
         if (tiles[tilenume].data == NULL)
         {
             free(rgba);
+            missingPngTile[missing_idx] |= missing_mask;
             return 0;
         }
     }
@@ -755,6 +775,7 @@ static int try_loadtile_from_override_png(short tilenume)
     }
 
     free(rgba);
+    missingPngTile[missing_idx] &= (uint8_t)~missing_mask;
     return 1;
 }
 
@@ -1055,6 +1076,7 @@ int loadpics(char  *filename, char * gamedir)
     prime_tile_override_metadata_from_png_headers();
 
     clearbuf(gotpic,(MAXTILES+31)>>5,0L);
+    clearbuf(missingPngTile,(MAXTILES+31)>>5,0L);
 
     // Size the tile cache depending on the amount of available RAM
     const size_t ext_free = heap_caps_get_free_size(MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);

--- a/duke3d-go/components/duke3d/Engine/tiles.c
+++ b/duke3d-go/components/duke3d/Engine/tiles.c
@@ -13,6 +13,7 @@
 
 #include <rg_system.h>
 #include "esp_attr.h"
+#include "esp_heap_caps.h"
 #include <lodepng.h>
 #include <ctype.h>
 #include <stdlib.h>
@@ -857,19 +858,7 @@ void loadtile(short tilenume)
     tileFilesize = tiles[tilenume].dim.width * tiles[tilenume].dim.height;
 
     if (tileFilesize <= 0)
-    {
-        static int missingTileWarnBudget = 64;
-        if (missingTileWarnBudget > 0)
-        {
-            missingTileWarnBudget--;
-            // printf("loadtile: tile %d has invalid size %" PRId32 " (w=%d h=%d, artfile=%d).\n",
-            //       (int)tilenume, tileFilesize,
-            //       (int)tiles[tilenume].dim.width,
-            //       (int)tiles[tilenume].dim.height,
-            //       (int)tilefilenum[tilenume]);
-        }
         return;
-    }
 
     i = tilefilenum[tilenume];
     if (i != artfilnum){
@@ -884,7 +873,7 @@ void loadtile(short tilenume)
         artfil = TCkopen4load(artfilename,0);
 
         if (artfil == -1){
-            RG_LOGW("loadtile: missing artfile '%s' for tile %d (w=%d h=%d); synthesizing transparent fallback",
+            RG_LOGW("loadtile: missing artfile '%s' (or PNG override) for tile %d (w=%d h=%d); synthesizing transparent fallback",
                     artfilename, (int)tilenume,
                     (int)tiles[tilenume].dim.width,
                     (int)tiles[tilenume].dim.height);
@@ -1067,9 +1056,33 @@ int loadpics(char  *filename, char * gamedir)
 
     clearbuf(gotpic,(MAXTILES+31)>>5,0L);
 
-    // When the primary GRP is memory-backed (ZIP extracted to RAM), use a
-    // moderate cache floor to improve runtime reuse while staying memory-safe.
-    const int32_t min_cache_size = groupfile_primary_is_memory_backed() ? (512 * 1024) : (1024 * 1024);
+    // Size the tile cache depending on the amount of available RAM
+    const size_t ext_free = heap_caps_get_free_size(MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    const size_t ext_largest = heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    // Reserve space for things other than tile cache;
+    // Not reserving enough will result in some textures failing to load, so they will be black, but still quite playable.
+    // Reserving too much space will result in little space left over for texture cache, making the game laggy.
+    const int32_t reserve_bytes = 640 * 1024; // 500KB has missing textures, 750KB is fine, 640KB seems to be the sweet spot
+    const int32_t dynamic_size = (int32_t)ext_largest - reserve_bytes;
+    int32_t min_cache_size = dynamic_size;
+
+    if (dynamic_size < 64 * 1024) {
+        RG_LOGW("loadpics: cache target ultra low, setting to minimum of 64KB");
+        min_cache_size = 64 * 1024;
+    } else if (dynamic_size < 512 * 1024) {
+        RG_LOGW("loadpics: cache target is low and might result in the game being slow due to frequent tile cache misses");
+    } else if (dynamic_size > 1536 * 1024) {
+        RG_LOGW("loadpics: cache target very high, setting to maximum of 1.5MB");
+        min_cache_size = 1536 * 1024;
+    }
+
+    RG_LOGW("loadpics: dynamic cache computed=%" PRId32 "KB, adjusted target=%" PRId32 "KB (ext free=%uKB largest=%uKB reserve=%" PRId32 "KB)",
+            (int32_t)(dynamic_size / 1024),
+            (int32_t)(min_cache_size / 1024),
+            (unsigned)(ext_free / 1024),
+            (unsigned)(ext_largest / 1024),
+            (int32_t)(reserve_bytes / 1024));
+
     cachesize = max(artsize, min_cache_size);
     cachesize = (cachesize + 15) & ~15; // Align size to 16 bytes
 

--- a/duke3d-go/components/duke3d/Game/menues.c
+++ b/duke3d-go/components/duke3d/Game/menues.c
@@ -405,13 +405,23 @@ int loadplayer(int8_t spot)
          drawbackground();
          menutext(160,100,0,0,"LOADING...");
          nextpage();
-    }
+     }
 
      waitforeverybody();
 
          FX_StopAllSounds();
      clearsoundlocks();
          MUSIC_StopSong();
+
+     if(numplayers <= 1)
+     {
+         pub = NUMPAGES;
+         pus = NUMPAGES;
+         vscrn();
+         drawbackground();
+         menutext(160,100,0,0,"LOADING SAVED GAME...");
+         nextpage();
+     }
 
      if(numplayers > 1)
          kdfread(&buf,19,1,fil);

--- a/duke3d-go/components/duke3d/Game/premap.c
+++ b/duke3d-go/components/duke3d/Game/premap.c
@@ -1586,6 +1586,12 @@ if (!VOLUMEONE)
     cacheit();
     docacheit();
 
+    // Restore screen_size before vscrn() so the viewport is sized correctly for the
+    // HUD from the very first frame; without this the demo/main-menu launch sees a
+    // full-screen viewport (screen_size==0) because vscrn() is called later while
+    // screen_size is still 0 (it was zeroed at the start of enterlevel for loading).
+    ud.screen_size = l;
+
     if(ud.recstat != 2)
     {
         music_select = (ud.volume_number*11) + ud.level_number;
@@ -1664,15 +1670,14 @@ if (!VOLUMEONE)
      flushpackets();
      waitforeverybody();
 
-     // Fade out loading screen and restore viewport for the game
+     // Fade out loading screen and apply the final viewport for the game
      if(ud.recstat != 2)
      {
          int32_t j;
          for(j=0;j<63;j+=7) palto(0,0,0,j);
          KB_FlushKeyboardQueue();
      }
-     vscrn();
-     ud.screen_size = l;
+     vscrn(); // screen_size already restored to l above; viewport is correctly sized here
 
      clearview(0L);
      drawbackground();

--- a/duke3d-go/components/duke3d/Game/premap.c
+++ b/duke3d-go/components/duke3d/Game/premap.c
@@ -1586,16 +1586,6 @@ if (!VOLUMEONE)
     cacheit();
     docacheit();
 
-    // Fade out loading screen and restore viewport for the game
-    if(ud.recstat != 2)
-    {
-        int32_t j;
-        for(j=0;j<63;j+=7) palto(0,0,0,j);
-        KB_FlushKeyboardQueue();
-    }
-    vscrn();
-    ud.screen_size = l;
-
     if(ud.recstat != 2)
     {
         music_select = (ud.volume_number*11) + ud.level_number;
@@ -1674,8 +1664,16 @@ if (!VOLUMEONE)
      flushpackets();
      waitforeverybody();
 
-     palto(0,0,0,0);
+     // Fade out loading screen and restore viewport for the game
+     if(ud.recstat != 2)
+     {
+         int32_t j;
+         for(j=0;j<63;j+=7) palto(0,0,0,j);
+         KB_FlushKeyboardQueue();
+     }
      vscrn();
+     ud.screen_size = l;
+
      clearview(0L);
      drawbackground();
 

--- a/duke3d-go/components/duke3d/Game/premap.c
+++ b/duke3d-go/components/duke3d/Game/premap.c
@@ -37,7 +37,6 @@ Prepared for public release: 03/21/2003 - Charlie Wiederhold, 3D Realms
 extern uint8_t  everyothertime;
 short which_palookup = 9;
 
-
 static void tloadtile(short tilenume)
 {
     gotpic[tilenume>>3] |= (1<<(tilenume&7));
@@ -276,7 +275,10 @@ void precachenecessarysounds(void)
         {
             j++;
             if( (j&7) == 0 )
+            {
                 getpackets();
+                _idle();
+            }
             getsound(i);
         }
 }
@@ -336,7 +338,11 @@ void docacheit(void)
     {
         loadtile((short)i);
         j++;
-        if((j&7) == 0) getpackets();
+        if((j&7) == 0)
+        {
+            getpackets();
+            _idle();
+        }
     }
 
     clearbufbyte(gotpic,sizeof(gotpic),0L);
@@ -1409,9 +1415,7 @@ void dofrontscreens(void)
         nextpage();
 
         for(j=63;j>0;j-=7) palto(0,0,0,j);
-
         KB_FlushKeyboardQueue();
-        ud.screen_size = i;
     }
     else
     {
@@ -1492,11 +1496,10 @@ void enterlevel(uint8_t  g)
     FX_SetReverb(0);
 
     // RG_LOGI("enterlevel: drawing background...");
-    i = ud.screen_size;
+    // Keep loading screen visible through the expensive work below
+    i = l = ud.screen_size;
     ud.screen_size = 0;
     dofrontscreens();
-    vscrn();
-    ud.screen_size = i;
 
 if (!VOLUMEONE)
 {
@@ -1550,6 +1553,8 @@ if (!VOLUMEONE)
     }
 }
 
+    l = i;
+
     // RG_LOGI("enterlevel: clearing gotpic...");
     clearbufbyte(gotpic,sizeof(gotpic),0L);
 
@@ -1580,6 +1585,16 @@ if (!VOLUMEONE)
 
     cacheit();
     docacheit();
+
+    // Fade out loading screen and restore viewport for the game
+    if(ud.recstat != 2)
+    {
+        int32_t j;
+        for(j=0;j<63;j+=7) palto(0,0,0,j);
+        KB_FlushKeyboardQueue();
+    }
+    vscrn();
+    ud.screen_size = l;
 
     if(ud.recstat != 2)
     {

--- a/duke3d-go/components/duke3d/Game/sounds.c
+++ b/duke3d-go/components/duke3d/Game/sounds.c
@@ -293,7 +293,6 @@ uint8_t  loadsound(uint16_t num)
     Sound[num].lock = 200;
     Sound[num].ptr = NULL;
 
-    // printf("loadsound: %d (%s), sizing %d, calling allocache\n", num, sounds[num], (int)l);
     allocache(&Sound[num].ptr,l,(uint8_t  *)&Sound[num].lock);
     if (Sound[num].ptr == NULL) {
         printf("loadsound: %d (%s), allocache FAILED! length=%"PRId32"\n", num, sounds[num], l);
@@ -682,4 +681,3 @@ void clearsoundlocks(void)
  
             lumplockbyte[i] = 199;
 }
-


### PR DESCRIPTION
Keep the loading screen naturally visible during expensive PNG tile decompression

- dofrontscreens(): drop premature scrsize restore
- enterlevel(): postpone fade-out to after cacheit()/docacheit()
- Add _idle() calls in work loops for audio/input responsiveness
- loadplayer(): add loading screen for single-player saves

This wasn't an issue on default .GRP files containing raw uncompressed images, but with the Duke Nano 3D .grp files containing EDuke32-style PNG files, the loading took a bit longer, and the load screen didn't properly wait for it.

For a new game, this resulted in the game being sluggish during the first few seconds. For a savegame load or restarted game after dying, there was no load screen at all, resulting in the first ~10 seconds being sluggish.

This fixes that by adding a "LOADING SAVED GAME" screen, and adjusting the code to wait properly.