### PR TITLE
Minor tweak to improve greenish tint in dark areas — precision-correct 6-bit palette to RGB565 conversion

### DIFF
--- a/duke3d-go/components/duke3d/Engine/display.c
+++ b/duke3d-go/components/duke3d/Engine/display.c
@@ -1348,24 +1348,19 @@ void WriteLastPaletteToFile(){
 
 int VBE_setPalette(uint8_t  *palettebuffer)
 {
-    static SDL_Color fmt_swap[256];
-    int i;
-
-    // printf("VBE_setPalette: entry\n");
-
     if (palettebuffer == NULL) return 0;
 
-    for (i = 0; i < 256; i++) {
+    // Duke3D palette values are 6-bit (0-63). Convert directly to RGB565 to
+    // avoid the 6->8->5/6 bit roundtrip that makes dark colors appear greenish.
+    // See SDL_SetPalette565() for details.
+    int ret = SDL_SetPalette565(palettebuffer);
+
+    for (int i = 0; i < 256; i++) {
         lastPalette[i*3+0] = palettebuffer[i*4+2]; // Red
         lastPalette[i*3+1] = palettebuffer[i*4+1]; // Green
         lastPalette[i*3+2] = palettebuffer[i*4+0]; // Blue
-
-        fmt_swap[i].r = (palettebuffer[i*4+2] << 2) | (palettebuffer[i*4+2] >> 4);
-        fmt_swap[i].g = (palettebuffer[i*4+1] << 2) | (palettebuffer[i*4+1] >> 4);
-        fmt_swap[i].b = (palettebuffer[i*4+0] << 2) | (palettebuffer[i*4+0] >> 4);
     }
 
-    int ret = SDL_SetColors(surface, fmt_swap, 0, 256);
     _updateScreenRect(0, 0, 0, 0);
     return ret;
 }

--- a/duke3d-go/components/duke3d/Engine/display.c
+++ b/duke3d-go/components/duke3d/Engine/display.c
@@ -1350,8 +1350,9 @@ int VBE_setPalette(uint8_t  *palettebuffer)
 {
     if (palettebuffer == NULL) return 0;
 
-    // Duke3D palette values are 6-bit (0-63). Convert directly to RGB565 to
-    // avoid the 6->8->5/6 bit roundtrip that makes dark colors appear greenish.
+    // Duke3D palette values are 6-bit (0-63). Convert to RGB565 via fill-expand
+    // to 8-bit + ceiling rounding, preserving tiny blue components (b6=1 -> b5=1)
+    // that would otherwise round to zero and make warm wall colors look green.
     // See SDL_SetPalette565() for details.
     int ret = SDL_SetPalette565(palettebuffer);
 

--- a/duke3d-go/components/duke3d/SDL/SDL_video.c
+++ b/duke3d-go/components/duke3d/SDL/SDL_video.c
@@ -194,6 +194,47 @@ int SDL_SetColors(SDL_Surface *surface, SDL_Color *colors, int firstcolor, int n
     return 1;
 }
 
+// Convert a Duke3D-style 6-bit palette (packed as B,G,R,unused per entry) directly
+// to RGB565, bypassing the 6->8->5/6 roundtrip used by the SDL_SetColors path.
+//
+// The structural issue with the old path (VBE_setPalette -> SDL_SetColors):
+//   6-bit source -> 8-bit via (v<<2)|(v>>4) -> SDL_Color -> r8>>3, g8>>2, b8>>3
+// Net effect: R/B are halved (v6>>1, floor), but G is an identity (lossless).
+// This asymmetry causes neutral dark grays (equal R,G,B source values) to appear
+// greenish: for any odd 6-bit value, R5=B5=floor(v/2)=0 while G6=v=1, giving a
+// pure-green pixel instead of near-black.
+//
+// Fix: work directly from the 6-bit source, and quantize green to the same
+// effective 5-bit precision as red/blue by zeroing the green LSB.
+// This ensures neutral grays stay neutral:
+//   r5 = v6 >> 1           (same 5-bit floor as before)
+//   g6 = (v6 >> 1) << 1    (5-bit precision, placed in 6-bit field with LSB=0)
+//   b5 = v6 >> 1           (same 5-bit floor as before)
+// For a neutral input (r=g=b=val): r5/31 == (g6>>1)/31 == b5/31 -> neutral gray.
+// Green's extra RGB565 bit is intentionally left zero; full-brightness colors
+// (val=63) still reach maximum: r5=31, g6=62, b5=31 (1/63 shy of pure white,
+// perceptually indistinguishable).
+int SDL_SetPalette565(const uint8_t *pal6)
+{
+    if (!screen_surface.palette) {
+        screen_surface.palette = rg_alloc(256 * 2, MEM_SLOW);
+    }
+    if (!screen_surface.palette) return 0;
+
+    for (int i = 0; i < 256; i++) {
+        // palettebuffer layout per entry: [B, G, R, unused] (each 6-bit, 0-63)
+        uint16_t r5 = pal6[i*4+2] >> 1;          // 6-bit -> 5-bit
+        uint16_t g6 = (pal6[i*4+1] >> 1) << 1;   // 6-bit -> 5-bit precision, in 6-bit field
+        uint16_t b5 = pal6[i*4+0] >> 1;          // 6-bit -> 5-bit
+        uint16_t v = (r5 << 11) | (g6 << 5) | b5;
+#if RG_SCREEN_PIXEL_FORMAT == 0 /* 565_BE */
+        v = (v >> 8) | (v << 8);
+#endif
+        screen_surface.palette[i] = v;
+    }
+    return 1;
+}
+
 SDL_Surface *SDL_SetVideoMode(int width, int height, int bpp, Uint32 flags)
 {
     if (primary_surface) {

--- a/duke3d-go/components/duke3d/SDL/SDL_video.c
+++ b/duke3d-go/components/duke3d/SDL/SDL_video.c
@@ -4,9 +4,6 @@
 #include "build.h"
 #include "freertos/semphr.h"
 #include "esp_timer.h"
-#include <math.h>
-
-extern int32_t curbrightness;
 
 static rg_surface_t screen_surface;
 
@@ -197,30 +194,17 @@ int SDL_SetColors(SDL_Surface *surface, SDL_Color *colors, int firstcolor, int n
     return 1;
 }
 
-// Convert a Duke3D-style 6-bit palette (packed as B,G,R,unused per entry) to RGB565,
-// with gamma correction that matches the original VGA CRT experience.
+// Convert a Duke3D-style 6-bit palette (packed as B,G,R,unused per entry) to RGB565.
 //
-// The original DOS game was designed for CRT monitors whose hardware applied ~gamma 2.2,
-// making dark linear palette values appear much brighter perceptually. On a modern LCD
-// with no hardware gamma, dark values look far too dark, causing the tiny blue components
-// in warm wall colors (e.g. b6=1) to be crushed — making those colors look yellow-green
-// instead of warm brown.
+// Brightness/gamma is handled upstream in setbrightness() via the britable[] table
+// (loaded from tables.dat), which applies the same power-curve correction as eDuke32.
+// This function's job is purely precision-correct channel conversion:
 //
-// Pipeline per channel:
 //   1. Fill-expand 6-bit to 8-bit: v8 = (v6 << 2) | (v6 >> 4)  (0->0, 63->255)
-//   2. Apply gamma lift via a precomputed 256-entry LUT:
-//        gamma_lut[v] = round(255 * pow(v/255.0, a))  where a = 8.0/(curbrightness+8)
-//      At curbrightness=0 (brightness slider min): a=1.0, identity — no correction.
-//      At curbrightness=4 (default, ud.brightness=16): a=0.667, moderate CRT-like lift.
-//      At curbrightness=14 (max): a=0.364, strong lift for very bright display setups.
-//      This exactly mirrors eDuke32's britable power curve, giving the same shadow
-//      detail and color balance as the PC reference version at equivalent settings.
-//   3. Ceiling-round to 5-bit (R,B): ((v + 4) >> 3) & 0x1F
-//      Ceiling-round to 6-bit (G):   ((v + 2) >> 2) & 0x3F
-//      The & mask (branchless cap) only fires for v=255, preventing overflow to 32/64.
-//
-// The LUT is rebuilt only when curbrightness changes (i.e. when the user moves the
-// brightness slider), so there is zero per-frame overhead.
+//   2. Ceiling-round to 5-bit (R,B): ((v8 + 4) >> 3) & 0x1F
+//      Ceiling-round to 6-bit (G):   ((v8 + 2) >> 2) & 0x3F
+//      The & mask (branchless cap) only fires at v8=255, preventing overflow to 32/64.
+//      Ceiling rounding preserves tiny values (e.g. b6=1 -> b5=1, not b5=0).
 int SDL_SetPalette565(const uint8_t *pal6)
 {
     if (!screen_surface.palette) {
@@ -228,27 +212,11 @@ int SDL_SetPalette565(const uint8_t *pal6)
     }
     if (!screen_surface.palette) return 0;
 
-    // Rebuild gamma LUT only when brightness changes.
-    static uint8_t gamma_lut[256];
-    static int32_t last_brightness = -1;
-
-    if (curbrightness != last_brightness) {
-        last_brightness = curbrightness;
-        // a = 8/(curbrightness+8): ranges from 1.0 (no lift) down to ~0.36 (strong lift),
-        // matching eDuke32's britable formula exactly.
-        float a = 8.0f / (float)(curbrightness + 8);
-        float b = 255.0f / powf(255.0f, a);
-        gamma_lut[0] = 0;
-        for (int v = 1; v < 256; v++) {
-            gamma_lut[v] = (uint8_t)(powf((float)v, a) * b + 0.5f);
-        }
-    }
-
     for (int i = 0; i < 256; i++) {
         // palettebuffer layout per entry: [B, G, R, unused] (each 6-bit, 0-63)
-        uint16_t r8 = gamma_lut[(pal6[i*4+2] << 2) | (pal6[i*4+2] >> 4)];
-        uint16_t g8 = gamma_lut[(pal6[i*4+1] << 2) | (pal6[i*4+1] >> 4)];
-        uint16_t b8 = gamma_lut[(pal6[i*4+0] << 2) | (pal6[i*4+0] >> 4)];
+        uint16_t r8 = (pal6[i*4+2] << 2) | (pal6[i*4+2] >> 4);
+        uint16_t g8 = (pal6[i*4+1] << 2) | (pal6[i*4+1] >> 4);
+        uint16_t b8 = (pal6[i*4+0] << 2) | (pal6[i*4+0] >> 4);
         uint16_t r5 = ((r8 + 4) >> 3) & 0x1F;
         uint16_t g6 = ((g8 + 2) >> 2) & 0x3F;
         uint16_t b5 = ((b8 + 4) >> 3) & 0x1F;

--- a/duke3d-go/components/duke3d/SDL/SDL_video.c
+++ b/duke3d-go/components/duke3d/SDL/SDL_video.c
@@ -201,10 +201,11 @@ int SDL_SetColors(SDL_Surface *surface, SDL_Color *colors, int firstcolor, int n
 // This function's job is purely precision-correct channel conversion:
 //
 //   1. Fill-expand 6-bit to 8-bit: v8 = (v6 << 2) | (v6 >> 4)  (0->0, 63->255)
-//   2. Ceiling-round to 5-bit (R,B): ((v8 + 4) >> 3) & 0x1F
-//      Ceiling-round to 6-bit (G):   ((v8 + 2) >> 2) & 0x3F
-//      The & mask (branchless cap) only fires at v8=255, preventing overflow to 32/64.
+//   2. Ceiling-round to 5-bit (R,B) with clamp: min(31, (v8 + 4) >> 3)
+//      Ceiling-round to 6-bit (G) with clamp:   min(63, (v8 + 2) >> 2)
 //      Ceiling rounding preserves tiny values (e.g. b6=1 -> b5=1, not b5=0).
+//      Clamping prevents overflow at v8=255: (255+4)>>3=32 -> clamped to 31.
+//      NOTE: Using min() instead of & mask because 32 & 0x1F = 0, not 31!
 int SDL_SetPalette565(const uint8_t *pal6)
 {
     if (!screen_surface.palette) {
@@ -217,9 +218,13 @@ int SDL_SetPalette565(const uint8_t *pal6)
         uint16_t r8 = (pal6[i*4+2] << 2) | (pal6[i*4+2] >> 4);
         uint16_t g8 = (pal6[i*4+1] << 2) | (pal6[i*4+1] >> 4);
         uint16_t b8 = (pal6[i*4+0] << 2) | (pal6[i*4+0] >> 4);
-        uint16_t r5 = ((r8 + 4) >> 3) & 0x1F;
-        uint16_t g6 = ((g8 + 2) >> 2) & 0x3F;
-        uint16_t b5 = ((b8 + 4) >> 3) & 0x1F;
+        // Ceiling-round with proper clamping (not masking which wraps 32->0)
+        uint16_t r5_raw = (r8 + 4) >> 3;
+        uint16_t g6_raw = (g8 + 2) >> 2;
+        uint16_t b5_raw = (b8 + 4) >> 3;
+        uint16_t r5 = r5_raw < 31 ? r5_raw : 31;
+        uint16_t g6 = g6_raw < 63 ? g6_raw : 63;
+        uint16_t b5 = b5_raw < 31 ? b5_raw : 31;
         uint16_t v = (r5 << 11) | (g6 << 5) | b5;
 #if RG_SCREEN_PIXEL_FORMAT == 0 /* 565_BE */
         v = (v >> 8) | (v << 8);

--- a/duke3d-go/components/duke3d/SDL/SDL_video.c
+++ b/duke3d-go/components/duke3d/SDL/SDL_video.c
@@ -194,26 +194,24 @@ int SDL_SetColors(SDL_Surface *surface, SDL_Color *colors, int firstcolor, int n
     return 1;
 }
 
-// Convert a Duke3D-style 6-bit palette (packed as B,G,R,unused per entry) directly
-// to RGB565, bypassing the 6->8->5/6 roundtrip used by the SDL_SetColors path.
+// Convert a Duke3D-style 6-bit palette (packed as B,G,R,unused per entry) to RGB565.
 //
-// The structural issue with the old path (VBE_setPalette -> SDL_SetColors):
-//   6-bit source -> 8-bit via (v<<2)|(v>>4) -> SDL_Color -> r8>>3, g8>>2, b8>>3
-// Net effect: R/B are halved (v6>>1, floor), but G is an identity (lossless).
-// This asymmetry causes neutral dark grays (equal R,G,B source values) to appear
-// greenish: for any odd 6-bit value, R5=B5=floor(v/2)=0 while G6=v=1, giving a
-// pure-green pixel instead of near-black.
+// Duke3D stores palette components as 6-bit values (0-63), matching the original
+// VGA DAC precision. Many wall/floor colors have a tiny blue component (e.g. b6=1)
+// that anchors warm browns away from yellow-green. Losing that component — which
+// both the old path and the first fix did — is the root cause of the green cast in
+// dark/shaded areas.
 //
-// Fix: work directly from the 6-bit source, and quantize green to the same
-// effective 5-bit precision as red/blue by zeroing the green LSB.
-// This ensures neutral grays stay neutral:
-//   r5 = v6 >> 1           (same 5-bit floor as before)
-//   g6 = (v6 >> 1) << 1    (5-bit precision, placed in 6-bit field with LSB=0)
-//   b5 = v6 >> 1           (same 5-bit floor as before)
-// For a neutral input (r=g=b=val): r5/31 == (g6>>1)/31 == b5/31 -> neutral gray.
-// Green's extra RGB565 bit is intentionally left zero; full-brightness colors
-// (val=63) still reach maximum: r5=31, g6=62, b5=31 (1/63 shy of pure white,
-// perceptually indistinguishable).
+// The correct pipeline:
+//   1. Fill-expand 6-bit to 8-bit: v8 = (v6 << 2) | (v6 >> 4)
+//      Maps 0->0 and 63->255 (full scale), preserving relative brightness.
+//   2. Round 8-bit to 5-bit (R,B): r5 = (v8 + 4) >> 3, capped at 31
+//      Ceiling-biased rounding ensures b6=1 -> b8=4 -> b5=1 (not 0).
+//   3. Round 8-bit to 6-bit (G):   g6 = (v8 + 2) >> 2, capped at 63
+//      Same principle; green keeps its full RGB565 precision.
+//
+// The cap (& 0x1F / & 0x3F) is only ever triggered for v6=63 (v8=255),
+// where truncation without cap would give 32/64. Branchless via bitmask.
 int SDL_SetPalette565(const uint8_t *pal6)
 {
     if (!screen_surface.palette) {
@@ -223,9 +221,12 @@ int SDL_SetPalette565(const uint8_t *pal6)
 
     for (int i = 0; i < 256; i++) {
         // palettebuffer layout per entry: [B, G, R, unused] (each 6-bit, 0-63)
-        uint16_t r5 = pal6[i*4+2] >> 1;          // 6-bit -> 5-bit
-        uint16_t g6 = (pal6[i*4+1] >> 1) << 1;   // 6-bit -> 5-bit precision, in 6-bit field
-        uint16_t b5 = pal6[i*4+0] >> 1;          // 6-bit -> 5-bit
+        uint16_t r8 = (pal6[i*4+2] << 2) | (pal6[i*4+2] >> 4);  // 6-bit -> 8-bit fill-expand
+        uint16_t g8 = (pal6[i*4+1] << 2) | (pal6[i*4+1] >> 4);
+        uint16_t b8 = (pal6[i*4+0] << 2) | (pal6[i*4+0] >> 4);
+        uint16_t r5 = ((r8 + 4) >> 3) & 0x1F;  // 8-bit -> 5-bit, ceiling rounding
+        uint16_t g6 = ((g8 + 2) >> 2) & 0x3F;  // 8-bit -> 6-bit, ceiling rounding
+        uint16_t b5 = ((b8 + 4) >> 3) & 0x1F;  // 8-bit -> 5-bit, ceiling rounding
         uint16_t v = (r5 << 11) | (g6 << 5) | b5;
 #if RG_SCREEN_PIXEL_FORMAT == 0 /* 565_BE */
         v = (v >> 8) | (v << 8);

--- a/duke3d-go/components/duke3d/SDL/SDL_video.c
+++ b/duke3d-go/components/duke3d/SDL/SDL_video.c
@@ -4,6 +4,9 @@
 #include "build.h"
 #include "freertos/semphr.h"
 #include "esp_timer.h"
+#include <math.h>
+
+extern int32_t curbrightness;
 
 static rg_surface_t screen_surface;
 
@@ -194,24 +197,30 @@ int SDL_SetColors(SDL_Surface *surface, SDL_Color *colors, int firstcolor, int n
     return 1;
 }
 
-// Convert a Duke3D-style 6-bit palette (packed as B,G,R,unused per entry) to RGB565.
+// Convert a Duke3D-style 6-bit palette (packed as B,G,R,unused per entry) to RGB565,
+// with gamma correction that matches the original VGA CRT experience.
 //
-// Duke3D stores palette components as 6-bit values (0-63), matching the original
-// VGA DAC precision. Many wall/floor colors have a tiny blue component (e.g. b6=1)
-// that anchors warm browns away from yellow-green. Losing that component — which
-// both the old path and the first fix did — is the root cause of the green cast in
-// dark/shaded areas.
+// The original DOS game was designed for CRT monitors whose hardware applied ~gamma 2.2,
+// making dark linear palette values appear much brighter perceptually. On a modern LCD
+// with no hardware gamma, dark values look far too dark, causing the tiny blue components
+// in warm wall colors (e.g. b6=1) to be crushed — making those colors look yellow-green
+// instead of warm brown.
 //
-// The correct pipeline:
-//   1. Fill-expand 6-bit to 8-bit: v8 = (v6 << 2) | (v6 >> 4)
-//      Maps 0->0 and 63->255 (full scale), preserving relative brightness.
-//   2. Round 8-bit to 5-bit (R,B): r5 = (v8 + 4) >> 3, capped at 31
-//      Ceiling-biased rounding ensures b6=1 -> b8=4 -> b5=1 (not 0).
-//   3. Round 8-bit to 6-bit (G):   g6 = (v8 + 2) >> 2, capped at 63
-//      Same principle; green keeps its full RGB565 precision.
+// Pipeline per channel:
+//   1. Fill-expand 6-bit to 8-bit: v8 = (v6 << 2) | (v6 >> 4)  (0->0, 63->255)
+//   2. Apply gamma lift via a precomputed 256-entry LUT:
+//        gamma_lut[v] = round(255 * pow(v/255.0, a))  where a = 8.0/(curbrightness+8)
+//      At curbrightness=0 (brightness slider min): a=1.0, identity — no correction.
+//      At curbrightness=4 (default, ud.brightness=16): a=0.667, moderate CRT-like lift.
+//      At curbrightness=14 (max): a=0.364, strong lift for very bright display setups.
+//      This exactly mirrors eDuke32's britable power curve, giving the same shadow
+//      detail and color balance as the PC reference version at equivalent settings.
+//   3. Ceiling-round to 5-bit (R,B): ((v + 4) >> 3) & 0x1F
+//      Ceiling-round to 6-bit (G):   ((v + 2) >> 2) & 0x3F
+//      The & mask (branchless cap) only fires for v=255, preventing overflow to 32/64.
 //
-// The cap (& 0x1F / & 0x3F) is only ever triggered for v6=63 (v8=255),
-// where truncation without cap would give 32/64. Branchless via bitmask.
+// The LUT is rebuilt only when curbrightness changes (i.e. when the user moves the
+// brightness slider), so there is zero per-frame overhead.
 int SDL_SetPalette565(const uint8_t *pal6)
 {
     if (!screen_surface.palette) {
@@ -219,14 +228,30 @@ int SDL_SetPalette565(const uint8_t *pal6)
     }
     if (!screen_surface.palette) return 0;
 
+    // Rebuild gamma LUT only when brightness changes.
+    static uint8_t gamma_lut[256];
+    static int32_t last_brightness = -1;
+
+    if (curbrightness != last_brightness) {
+        last_brightness = curbrightness;
+        // a = 8/(curbrightness+8): ranges from 1.0 (no lift) down to ~0.36 (strong lift),
+        // matching eDuke32's britable formula exactly.
+        float a = 8.0f / (float)(curbrightness + 8);
+        float b = 255.0f / powf(255.0f, a);
+        gamma_lut[0] = 0;
+        for (int v = 1; v < 256; v++) {
+            gamma_lut[v] = (uint8_t)(powf((float)v, a) * b + 0.5f);
+        }
+    }
+
     for (int i = 0; i < 256; i++) {
         // palettebuffer layout per entry: [B, G, R, unused] (each 6-bit, 0-63)
-        uint16_t r8 = (pal6[i*4+2] << 2) | (pal6[i*4+2] >> 4);  // 6-bit -> 8-bit fill-expand
-        uint16_t g8 = (pal6[i*4+1] << 2) | (pal6[i*4+1] >> 4);
-        uint16_t b8 = (pal6[i*4+0] << 2) | (pal6[i*4+0] >> 4);
-        uint16_t r5 = ((r8 + 4) >> 3) & 0x1F;  // 8-bit -> 5-bit, ceiling rounding
-        uint16_t g6 = ((g8 + 2) >> 2) & 0x3F;  // 8-bit -> 6-bit, ceiling rounding
-        uint16_t b5 = ((b8 + 4) >> 3) & 0x1F;  // 8-bit -> 5-bit, ceiling rounding
+        uint16_t r8 = gamma_lut[(pal6[i*4+2] << 2) | (pal6[i*4+2] >> 4)];
+        uint16_t g8 = gamma_lut[(pal6[i*4+1] << 2) | (pal6[i*4+1] >> 4)];
+        uint16_t b8 = gamma_lut[(pal6[i*4+0] << 2) | (pal6[i*4+0] >> 4)];
+        uint16_t r5 = ((r8 + 4) >> 3) & 0x1F;
+        uint16_t g6 = ((g8 + 2) >> 2) & 0x3F;
+        uint16_t b5 = ((b8 + 4) >> 3) & 0x1F;
         uint16_t v = (r5 << 11) | (g6 << 5) | b5;
 #if RG_SCREEN_PIXEL_FORMAT == 0 /* 565_BE */
         v = (v >> 8) | (v << 8);

--- a/duke3d-go/components/duke3d/SDL/SDL_video.h
+++ b/duke3d-go/components/duke3d/SDL/SDL_video.h
@@ -112,6 +112,7 @@ SDL_Keymod SDL_GetModState(void);
 SDL_Surface *SDL_GetVideoSurface(void);
 Uint32 SDL_MapRGB(SDL_PixelFormat *fmt, Uint8 r, Uint8 g, Uint8 b);
 int SDL_SetColors(SDL_Surface *surface, SDL_Color *colors, int firstcolor, int ncolors);
+int SDL_SetPalette565(const uint8_t *pal6);
 SDL_Surface *SDL_SetVideoMode(int width, int height, int bpp, Uint32 flags);
 void SDL_FreeSurface(SDL_Surface *surface);
 void SDL_QuitSubSystem(Uint32 flags);


### PR DESCRIPTION
Dark and shaded areas in Duke3D had a visible greenish/yellow-green tint, most noticeable in corridors and on walls, especially on the Fri3d 2024 device.

I first suspected the same issue as https://github.com/a159x36/qemu/pull/4 but it was the same symptom, different cause.

In the end, the issue turns out to be much worse on the old Fri3d 2024 display than on the Fri3d 2026 device, even though they use the same ST7789 controller, the same initialization, the same ScreenGamma (as far as I know) and also, the issue gets worse with higher ScreenGamma so lowering the default 12.5% to 0% also helps.

Anyway, investigating this did cause me to find this one minor bug regarding `VBE_setPalette` -> `SDL_SetColors`: Duke3D's 6-bit palette values (0–63 per channel) were converted to RGB565 through a pipeline that gave green more effective precision than red and blue:

```
R, B:  v6 → v8 via (v<<2)|(v>>4) → r5 = v8 >> 3   (floor — lossy)
G:     v6 → v8 via (v<<2)|(v>>4) → g6 = v8 >> 2   (floor — lossless, keeps full range)
```

For palette entries with small odd source values — like the `b6=1` blue component that anchors Duke3D's warm wall/floor colors as brown rather than green — `floor(1/2) = 0`, and blue disappeared entirely. With `R5=B5=0` and `G6` non-zero, those pixels rendered green instead of their intended warm-brown.

### Fix

Replace the `SDL_SetColors` path with a new `SDL_SetPalette565()` that converts directly from the 6-bit source to RGB565:

1. **Fill-expand** 6-bit → 8-bit: `v8 = (v6 << 2) | (v6 >> 4)` — maps 0→0 and 63→255 correctly.
2. **Ceiling-round** to 5-bit (R, B): `min(31, (v8 + 4) >> 3)` — preserves small values (`b6=1 → b5=1` instead of 0).
3. **Ceiling-round** to 6-bit (G): `min(63, (v8 + 2) >> 2)` — green keeps full RGB565 precision, matching R/B's effective range. `min()` is used instead of `& mask` because `32 & 0x1F = 0`, which would corrupt max-brightness channels.

Also removes the 1 KB static `SDL_Color fmt_swap[256]` intermediate buffer, which is nice.

### Result

Warm wall and floor colors that were previously missing their blue component now render correctly:

| Palette entry | Before | After |
|---|---|---|
| `pal[145]` (26, 20, **1**) | (13, 20, **0**) | (13, 20, **1**) |
| `pal[146]` (29, 22, **1**) | (14, 22, **0**) | (15, 22, **1**) |
| `pal[147]` (32, 25, **1**) | (16, 24, **0**) | (16, 25, **1**) |

Dark corridors and shaded walls now have better warm-brown tones, although the effect is minimal.

# Comparison

It's hard to capture this with a picture, especially with ambient lighting and camera processing playing a role, but I gave it a go.

## Fire Hydrant

I took these pictures while standing on the fire hydrant and aiming at the flame, to have something consistent.

Before, with the areas that are fixed by this change marked, but also note the general green-ish color.

<img width="1213" height="910" alt="image" src="https://github.com/user-attachments/assets/4ef7f1a2-e027-4345-ab38-8f8d97c16fb1" />

After:

<img width="1213" height="910" alt="image" src="https://github.com/user-attachments/assets/2e1e8235-89fa-42ad-aecc-f3c087a74523" />

## Corner

These were taken standing in the corner and aiming at the door.

Again, marked the changes and note that the colors overall are less greenish.

Before:

<img width="1213" height="910" alt="image" src="https://github.com/user-attachments/assets/79917923-5aa2-461b-b510-68fca34de397" />

After:

<img width="1213" height="910" alt="image" src="https://github.com/user-attachments/assets/f8f3e234-76b0-4c62-8435-badcf564f86b" />


# Performance impact

As this palette code only runs at the start of the game, not per frame, there's no impact.