### PR TITLE
Add cheats menu under Options -> Game Options

### DIFF
--- a/duke3d-go/components/duke3d/Game/funct.h
+++ b/duke3d-go/components/duke3d/Game/funct.h
@@ -399,6 +399,7 @@ extern short spawn(short j,short pn);
 //#line "game.c" 4181
 extern void animatesprites(int32_t x,int32_t y,short a,int32_t smoothratio);
 //#line "game.c" 4859
+extern void activate_cheat(int k);
 extern void cheats(void );
 //#line "game.c" 5303
 extern void nonsharedkeys(void );

--- a/duke3d-go/components/duke3d/Game/game.c
+++ b/duke3d-go/components/duke3d/Game/game.c
@@ -6193,9 +6193,190 @@ const uint8_t  cheatquotes[NUMCHEATCODES][14] = {
 
 
 uint8_t  cheatbuf[10],cheatbuflen;
+
+// Activate a cheat directly by its index into cheatquotes[].
+// Used both by the keyboard-input path (cheats()) and the menu cheat picker.
+// Cheats that require typed parameters (warp/skill, indices 2 and 10) are
+// intentionally excluded from the menu path and are not handled here.
+void activate_cheat(int k)
+{
+    short i, j, weapon;
+
+    switch(k)
+    {
+        case 0:  // cornholio
+        case 18: // kroz — same effect: toggle god mode
+            ud.god = 1-ud.god;
+            if(ud.god)
+            {
+                pus = 1;
+                pub = 1;
+                sprite[ps[myconnectindex].i].cstat = 257;
+                hittype[ps[myconnectindex].i].temp_data[0] = 0;
+                hittype[ps[myconnectindex].i].temp_data[1] = 0;
+                hittype[ps[myconnectindex].i].temp_data[2] = 0;
+                hittype[ps[myconnectindex].i].temp_data[3] = 0;
+                hittype[ps[myconnectindex].i].temp_data[4] = 0;
+                hittype[ps[myconnectindex].i].temp_data[5] = 0;
+                sprite[ps[myconnectindex].i].hitag = 0;
+                sprite[ps[myconnectindex].i].lotag = 0;
+                sprite[ps[myconnectindex].i].pal = ps[myconnectindex].palookup;
+                FTA(17,&ps[myconnectindex],1);
+            }
+            else
+            {
+                ud.god = 0;
+                sprite[ps[myconnectindex].i].extra = max_player_health;
+                hittype[ps[myconnectindex].i].extra = -1;
+                ps[myconnectindex].last_extra = max_player_health;
+                FTA(18,&ps[myconnectindex],1);
+            }
+            sprite[ps[myconnectindex].i].extra = max_player_health;
+            hittype[ps[myconnectindex].i].extra = 0;
+            break;
+
+        case 1: // stuff — all weapons, ammo, inventory and keys
+            j = VOLUMEONE ? 6 : 0;
+            for(weapon = PISTOL_WEAPON; weapon < MAX_WEAPONS-j; weapon++)
+                ps[myconnectindex].gotweapon[weapon] = 1;
+            for(weapon = PISTOL_WEAPON; weapon < MAX_WEAPONS-j; weapon++)
+                addammo(weapon, &ps[myconnectindex], max_ammo_amount[weapon]);
+            ps[myconnectindex].ammo_amount[GROW_WEAPON] = 50;
+            ps[myconnectindex].steroids_amount  = 400;
+            ps[myconnectindex].heat_amount      = 1200;
+            ps[myconnectindex].boot_amount      = 200;
+            ps[myconnectindex].shield_amount    = 100;
+            ps[myconnectindex].scuba_amount     = 6400;
+            ps[myconnectindex].holoduke_amount  = 2400;
+            ps[myconnectindex].jetpack_amount   = 1600;
+            ps[myconnectindex].firstaid_amount  = max_player_health;
+            ps[myconnectindex].got_access       = 7;
+            ps[myconnectindex].inven_icon       = 1;
+            FTA(5,&ps[myconnectindex],1);
+            break;
+
+        case 3: // coords — toggle coordinate display
+            ud.coords = 1-ud.coords;
+            break;
+
+        case 4: // view — toggle over-shoulder camera
+            if(ps[myconnectindex].over_shoulder_on)
+                ps[myconnectindex].over_shoulder_on = 0;
+            else
+            {
+                ps[myconnectindex].over_shoulder_on = 1;
+                cameradist = 0;
+                cameraclock = totalclock;
+            }
+            break;
+
+        case 6: // unlock — open all locked sectors
+            for(i=numsectors-1; i>=0; i--)
+            {
+                j = sector[i].lotag;
+                if(j == -1 || j == 32767) continue;
+                if((j & 0x7fff) > 2)
+                {
+                    if(j&(0xffff-16384))
+                        sector[i].lotag &= (0xffff-16384);
+                    operatesectors(i,ps[myconnectindex].i);
+                }
+            }
+            operateforcefields(ps[myconnectindex].i,-1);
+            FTA(100,&ps[myconnectindex],1);
+            break;
+
+        case 7: // cashman
+            ud.cashman = 1-ud.cashman;
+            break;
+
+        case 8: // items — all inventory and keys
+            ps[myconnectindex].steroids_amount  = 400;
+            ps[myconnectindex].heat_amount      = 1200;
+            ps[myconnectindex].boot_amount      = 200;
+            ps[myconnectindex].shield_amount    = 100;
+            ps[myconnectindex].scuba_amount     = 6400;
+            ps[myconnectindex].holoduke_amount  = 2400;
+            ps[myconnectindex].jetpack_amount   = 1600;
+            ps[myconnectindex].firstaid_amount  = max_player_health;
+            ps[myconnectindex].got_access       = 7;
+            FTA(5,&ps[myconnectindex],1);
+            break;
+
+        case 9: // rate — toggle FPS display
+            ud.tickrate ^= 1;
+            vscrn();
+            break;
+
+        case 12: // hyper — steroids + nightvision
+            ps[myconnectindex].steroids_amount = 399;
+            ps[myconnectindex].heat_amount     = 1200;
+            FTA(37,&ps[myconnectindex],1);
+            break;
+
+        case 13: // monsters — toggle: 0=on 1=invisible/off
+            actor_tog = actor_tog ? 0 : 1;
+            break;
+
+        case 17: // showmap — toggle full map reveal
+            ud.showallmap = 1-ud.showallmap;
+            if(ud.showallmap)
+            {
+                for(i=0; i<(MAXSECTORS>>3); i++) show2dsector[i] = 255;
+                for(i=0; i<(MAXWALLS>>3);   i++) show2dwall[i]   = 255;
+                FTA(111,&ps[myconnectindex],1);
+            }
+            else
+            {
+                for(i=0; i<(MAXSECTORS>>3); i++) show2dsector[i] = 0;
+                for(i=0; i<(MAXWALLS>>3);   i++) show2dwall[i]   = 0;
+                FTA(1,&ps[myconnectindex],1);
+            }
+            break;
+
+        case 20: // clip — toggle noclip
+            ud.clipping = 1-ud.clipping;
+            FTA(112+ud.clipping,&ps[myconnectindex],1);
+            break;
+
+        case 21: // weapons — all weapons and ammo
+            j = VOLUMEONE ? 6 : 0;
+            for(weapon = PISTOL_WEAPON; weapon < MAX_WEAPONS-j; weapon++)
+            {
+                addammo(weapon, &ps[myconnectindex], max_ammo_amount[weapon]);
+                ps[myconnectindex].gotweapon[weapon] = 1;
+            }
+            FTA(119,&ps[myconnectindex],1);
+            break;
+
+        case 22: // inventory — all inventory items
+            ps[myconnectindex].steroids_amount  = 400;
+            ps[myconnectindex].heat_amount      = 1200;
+            ps[myconnectindex].boot_amount      = 200;
+            ps[myconnectindex].shield_amount    = 100;
+            ps[myconnectindex].scuba_amount     = 6400;
+            ps[myconnectindex].holoduke_amount  = 2400;
+            ps[myconnectindex].jetpack_amount   = 1600;
+            ps[myconnectindex].firstaid_amount  = max_player_health;
+            FTA(120,&ps[myconnectindex],1);
+            break;
+
+        case 23: // keys — all key cards
+            ps[myconnectindex].got_access = 7;
+            FTA(121,&ps[myconnectindex],1);
+            break;
+
+        case 24: // debug
+            debug_on = 1-debug_on;
+            break;
+    }
+
+    ps[myconnectindex].cheat_phase = 0;
+}
+
 void cheats(void)
 {
-    short ch, i, j, k, weapon;
+    short ch, i, j, k;
 
     if( (ps[myconnectindex].gm&MODE_TYPE) || (ps[myconnectindex].gm&MODE_MENU))
         return;
@@ -6241,369 +6422,60 @@ void cheats(void)
 
           FOUNDCHEAT:
           {
-                switch(k)
+                // Warp/skill cheats need the typed digits from cheatbuf, so
+                // they stay inline here rather than going through activate_cheat().
+                if(k == 2 || k == 10) // scotty### / skill#
                 {
-                    case 0: // cornholio
-                    case 18: // kroz
+                    if(k == 2)
+                    {
+                        short volnume = cheatbuf[6] - '0';
+                        short levnume = (cheatbuf[7] - '0')*10 + (cheatbuf[8]-'0');
+                        volnume--;
+                        levnume--;
+                        if(VOLUMEONE && volnume > 0)
+                        { ps[myconnectindex].cheat_phase = 0; KB_FlushKeyboardQueue(); return; }
+                        if(((volnume > 4)&&PLUTOPAK) || ((volnume > 3)&&!PLUTOPAK))
+                        { ps[myconnectindex].cheat_phase = 0; KB_FlushKeyboardQueue(); return; }
+                        if(volnume == 0 && levnume > 5)
+                        { ps[myconnectindex].cheat_phase = 0; KB_FlushKeyboardQueue(); return; }
+                        if(volnume != 0 && levnume >= 11)
+                        { ps[myconnectindex].cheat_phase = 0; KB_FlushKeyboardQueue(); return; }
+                        ud.m_volume_number = ud.volume_number = volnume;
+                        ud.m_level_number  = ud.level_number  = levnume;
+                    }
+                    else
+                        ud.m_player_skill = ud.player_skill = cheatbuf[5] - '1';
 
-                        ud.god = 1-ud.god;
+                    if(numplayers > 1 && myconnectindex == connecthead)
+                    {
+                        tempbuf[0]  = 5;
+                        tempbuf[1]  = ud.m_level_number;
+                        tempbuf[2]  = ud.m_volume_number;
+                        tempbuf[3]  = ud.m_player_skill;
+                        tempbuf[4]  = ud.m_monsters_off;
+                        tempbuf[5]  = ud.m_respawn_monsters;
+                        tempbuf[6]  = ud.m_respawn_items;
+                        tempbuf[7]  = ud.m_respawn_inventory;
+                        tempbuf[8]  = ud.m_coop;
+                        tempbuf[9]  = ud.m_marker;
+                        tempbuf[10] = ud.m_ffire;
+                        for(i=connecthead;i>=0;i=connectpoint2[i])
+                            sendpacket(i,(uint8_t*)tempbuf,11);
+                    }
+                    else ps[myconnectindex].gm |= MODE_RESTART;
 
-                        if(ud.god)
-                        { // set on
-                            pus = 1;
-                            pub = 1;
-                            sprite[ps[myconnectindex].i].cstat = 257;
-
-                            hittype[ps[myconnectindex].i].temp_data[0] = 0;
-                            hittype[ps[myconnectindex].i].temp_data[1] = 0;
-                            hittype[ps[myconnectindex].i].temp_data[2] = 0;
-                            hittype[ps[myconnectindex].i].temp_data[3] = 0;
-                            hittype[ps[myconnectindex].i].temp_data[4] = 0;
-                            hittype[ps[myconnectindex].i].temp_data[5] = 0;
-
-                            sprite[ps[myconnectindex].i].hitag = 0;
-                            sprite[ps[myconnectindex].i].lotag = 0;
-                            sprite[ps[myconnectindex].i].pal =
-                                ps[myconnectindex].palookup;
-
-                            FTA(17,&ps[myconnectindex],1);
-                        }
-                        else // set off
-                        {
-                            ud.god = 0;
-                            sprite[ps[myconnectindex].i].extra = max_player_health;
-                            hittype[ps[myconnectindex].i].extra = -1;
-                            ps[myconnectindex].last_extra = max_player_health;
-                            FTA(18,&ps[myconnectindex],1);
-                        }
-
-                        sprite[ps[myconnectindex].i].extra = max_player_health;
-                        hittype[ps[myconnectindex].i].extra = 0;
-                        ps[myconnectindex].cheat_phase = 0;
-                        KB_FlushKeyboardQueue();
-
-                        return;
-
-                    case 1: // stuff
-
-						if(VOLUMEONE)
-                        	j = 6;
-						else
-                        	j = 0;
-
-                        for ( weapon = PISTOL_WEAPON;weapon < MAX_WEAPONS-j;weapon++ )
-                           ps[myconnectindex].gotweapon[weapon]  = 1;
-
-                        for ( weapon = PISTOL_WEAPON;
-                              weapon < (MAX_WEAPONS-j);
-                              weapon++ )
-                            addammo( weapon, &ps[myconnectindex], max_ammo_amount[weapon] );
-
-                        ps[myconnectindex].ammo_amount[GROW_WEAPON] = 50;
-
-                        ps[myconnectindex].steroids_amount =         400;
-                        ps[myconnectindex].heat_amount     =        1200;
-                        ps[myconnectindex].boot_amount          =    200;
-                        ps[myconnectindex].shield_amount =           100;
-                        ps[myconnectindex].scuba_amount =            6400;
-                        ps[myconnectindex].holoduke_amount =         2400;
-                        ps[myconnectindex].jetpack_amount =          1600;
-                        ps[myconnectindex].firstaid_amount =         max_player_health;
-
-                        ps[myconnectindex].got_access =              7;
-                        FTA(5,&ps[myconnectindex],1);
-                        ps[myconnectindex].cheat_phase = 0;
-
-                        ps[myconnectindex].cheat_phase = 0;
-                        KB_FlushKeyboardQueue();
-                        ps[myconnectindex].inven_icon = 1;
-                        return;
-
-                    case 2:  // dnscotty###
-                    case 10: // skill#
-
-                        if(k == 2)
-                        {
-                            short volnume,levnume;
-                            volnume = cheatbuf[6] - '0';
-                            levnume = (cheatbuf[7] - '0')*10+(cheatbuf[8]-'0');
-
-                            volnume--;
-                            levnume--;
-							if (VOLUMEONE)
-							{
-								if( volnume > 0 )
-	                            {
-	                                ps[myconnectindex].cheat_phase = 0;
-	                                KB_FlushKeyboardQueue();
-	                                return;
-	                            }
-							}
-
-                            if((volnume > 4)&&PLUTOPAK)
-                            {
-                                ps[myconnectindex].cheat_phase = 0;
-                                KB_FlushKeyboardQueue();
-                                return;
-                            }
-                            else
-
-							if((volnume > 3)&&!PLUTOPAK)
-                            {
-                                ps[myconnectindex].cheat_phase = 0;
-                                KB_FlushKeyboardQueue();
-                                return;
-                            }
-                            else
-
-                            if(volnume == 0)
-                            {
-                                if(levnume > 5)
-                                {
-                                    ps[myconnectindex].cheat_phase = 0;
-                                    KB_FlushKeyboardQueue();
-                                    return;
-                                }
-                            }
-                            else
-                            {
-                                if(levnume >= 11)
-                                {
-                                    ps[myconnectindex].cheat_phase = 0;
-                                    KB_FlushKeyboardQueue();
-                                    return;
-                                }
-                            }
-
-                            ud.m_volume_number = ud.volume_number = volnume;
-                            ud.m_level_number = ud.level_number = levnume;
-
-                        }
-                        else ud.m_player_skill = ud.player_skill =
-                            cheatbuf[5] - '1';
-
-                        if(numplayers > 1 && myconnectindex == connecthead)
-                        {
-                            tempbuf[0] = 5;
-                            tempbuf[1] = ud.m_level_number;
-                            tempbuf[2] = ud.m_volume_number;
-                            tempbuf[3] = ud.m_player_skill;
-                            tempbuf[4] = ud.m_monsters_off;
-                            tempbuf[5] = ud.m_respawn_monsters;
-                            tempbuf[6] = ud.m_respawn_items;
-                            tempbuf[7] = ud.m_respawn_inventory;
-                            tempbuf[8] = ud.m_coop;
-                            tempbuf[9] = ud.m_marker;
-                            tempbuf[10] = ud.m_ffire;
-
-                            for(i=connecthead;i>=0;i=connectpoint2[i])
-                                sendpacket(i,(uint8_t*)tempbuf,11);
-                        }
-                        else ps[myconnectindex].gm |= MODE_RESTART;
-
-                        ps[myconnectindex].cheat_phase = 0;
-                        KB_FlushKeyboardQueue();
-                        return;
-
-                    case 3: // coords
-                        ps[myconnectindex].cheat_phase = 0;
-                        ud.coords = 1-ud.coords;
-                        KB_FlushKeyboardQueue();
-                        return;
-
-                    case 4: // view
-                        if( ps[myconnectindex].over_shoulder_on )
-                            ps[myconnectindex].over_shoulder_on = 0;
-                        else
-                        {
-                            ps[myconnectindex].over_shoulder_on = 1;
-                            cameradist = 0;
-                            cameraclock = totalclock;
-                        }
-                        // FTA(22,&ps[myconnectindex],1);
-                        ps[myconnectindex].cheat_phase = 0;
-                        KB_FlushKeyboardQueue();
-                        return;
-
-                    case 5: // time
-                        // FTA(21,&ps[myconnectindex]);
-                        ps[myconnectindex].cheat_phase = 0;
-                        KB_FlushKeyboardQueue();
-                        return;
-
-					case 6: // unlock
-                        for(i=numsectors-1;i>=0;i--) //Unlock
-                        {
-                            j = sector[i].lotag;
-                            if(j == -1 || j == 32767) continue;
-                            if( (j & 0x7fff) > 2 )
-                            {
-                                if( j&(0xffff-16384) )
-                                    sector[i].lotag &= (0xffff-16384);
-                                operatesectors(i,ps[myconnectindex].i);
-                            }
-                        }
-                        operateforcefields(ps[myconnectindex].i,-1);
-
-                        FTA(100,&ps[myconnectindex],1);
-                        ps[myconnectindex].cheat_phase = 0;
-                        KB_FlushKeyboardQueue();
-                        return;
-
-                    case 7: // cashman
-                        ud.cashman = 1-ud.cashman;
-                        KB_ClearKeyDown(sc_N);
-                        ps[myconnectindex].cheat_phase = 0;
-                        return;
-
-                    case 8: // items
-                        ps[myconnectindex].steroids_amount =         400;
-                        ps[myconnectindex].heat_amount     =        1200;
-                        ps[myconnectindex].boot_amount          =    200;
-                        ps[myconnectindex].shield_amount =           100;
-                        ps[myconnectindex].scuba_amount =            6400;
-                        ps[myconnectindex].holoduke_amount =         2400;
-                        ps[myconnectindex].jetpack_amount =          1600;
-
-                        ps[myconnectindex].firstaid_amount =         max_player_health;
-                        ps[myconnectindex].got_access =              7;
-                        FTA(5,&ps[myconnectindex],1);
-                        ps[myconnectindex].cheat_phase = 0;
-                        KB_FlushKeyboardQueue();
-                        return;
-
-                    case 9: // rate
-                        ud.tickrate ^= 1;
-						vscrn(); // FIX_00056: Refresh issue w/FPS, small Weapon and custom FTA, when screen resized down
-                        ps[myconnectindex].cheat_phase = 0;
-                        KB_FlushKeyboardQueue();
-                        return;
-
-                    case 11: // beta
-                        FTA(105,&ps[myconnectindex],1);
-                        KB_ClearKeyDown(sc_H);
-                        ps[myconnectindex].cheat_phase = 0;
-                        KB_FlushKeyboardQueue();
-                        return;
-
-                    case 12: // hyper
-                        ps[myconnectindex].steroids_amount = 399;
-                        ps[myconnectindex].heat_amount = 1200;
-                        ps[myconnectindex].cheat_phase = 0;
-                        FTA(37,&ps[myconnectindex],1);
-                        KB_FlushKeyboardQueue();
-                        return;
-
-                    case 13: // monsters
-                        if(actor_tog == 3) actor_tog = 0;
-                        actor_tog++;
-                        ps[screenpeek].cheat_phase = 0;
-                        KB_FlushKeyboardQueue();
-                        return;
-
-                    case 14: // <RESERVED>
-                    case 25: // ??
-                        ud.eog = 1;
-                        ps[myconnectindex].gm |= MODE_EOL;
-                        KB_FlushKeyboardQueue();
-                        return;
-
-                    case 15: // <RESERVED>
-                        ps[myconnectindex].gm = MODE_EOL;
-                        ps[myconnectindex].cheat_phase = 0;
-                        KB_FlushKeyboardQueue();
-                        return;
-
-                    case 16: // todd
-                        FTA(99,&ps[myconnectindex],1);
-                        ps[myconnectindex].cheat_phase = 0;
-                        KB_FlushKeyboardQueue();
-                        return;
-
-                   case 17: // showmap
-                        ud.showallmap = 1-ud.showallmap;
-                        if(ud.showallmap)
-                        {
-                            for(i=0;i<(MAXSECTORS>>3);i++)
-                                show2dsector[i] = 255;
-                            for(i=0;i<(MAXWALLS>>3);i++)
-                                show2dwall[i] = 255;
-                            FTA(111,&ps[myconnectindex],1);
-                        }
-                        else
-                        {
-                            for(i=0;i<(MAXSECTORS>>3);i++)
-                                show2dsector[i] = 0;
-                            for(i=0;i<(MAXWALLS>>3);i++)
-                                show2dwall[i] = 0;
-                            FTA(1,&ps[myconnectindex],1);
-                        }
-                        ps[myconnectindex].cheat_phase = 0;
-                        KB_FlushKeyboardQueue();
-                        return;
-
-                    case 19: // allen
-                        FTA(79,&ps[myconnectindex],1);
-                        ps[myconnectindex].cheat_phase = 0;
-                        KB_ClearKeyDown(sc_N);
-                        return;
-
-					case 20: // clip
-                        ud.clipping = 1-ud.clipping;
-                        KB_FlushKeyboardQueue();
-                        ps[myconnectindex].cheat_phase = 0;
-                        FTA(112+ud.clipping,&ps[myconnectindex],1);
-                        return;
-
-					case 21: // weapons
-						if(VOLUMEONE)
-                        	j = 6;
-						else
-                        	j = 0;
-
-                        for ( weapon = PISTOL_WEAPON;weapon < MAX_WEAPONS-j;weapon++ )
-                        {
-                            addammo( weapon, &ps[myconnectindex], max_ammo_amount[weapon] );
-                            ps[myconnectindex].gotweapon[weapon]  = 1;
-                        }
-
-                        KB_FlushKeyboardQueue();
-                        ps[myconnectindex].cheat_phase = 0;
-                        FTA(119,&ps[myconnectindex],1);
-                        return;
-
-                    case 22: // inventory
-                        KB_FlushKeyboardQueue();
-                        ps[myconnectindex].cheat_phase = 0;
-                        ps[myconnectindex].steroids_amount =         400;
-                        ps[myconnectindex].heat_amount     =        1200;
-                        ps[myconnectindex].boot_amount          =    200;
-                        ps[myconnectindex].shield_amount =           100;
-                        ps[myconnectindex].scuba_amount =            6400;
-                        ps[myconnectindex].holoduke_amount =         2400;
-                        ps[myconnectindex].jetpack_amount =          1600;
-                        ps[myconnectindex].firstaid_amount =         max_player_health;
-                        FTA(120,&ps[myconnectindex],1);
-                        ps[myconnectindex].cheat_phase = 0;
-                        return;
-
-                    case 23: // keys
-                        ps[myconnectindex].got_access =              7;
-                        KB_FlushKeyboardQueue();
-                        ps[myconnectindex].cheat_phase = 0;
-                        FTA(121,&ps[myconnectindex],1);
-                        return;
-
-                    case 24: // debug
-                        debug_on = 1-debug_on;
-                        KB_FlushKeyboardQueue();
-                        ps[myconnectindex].cheat_phase = 0;
-                        break;
+                    ps[myconnectindex].cheat_phase = 0;
+                    KB_FlushKeyboardQueue();
+                    return;
                 }
-             }
+
+                // All other cheats go through the shared helper.
+                activate_cheat(k);
+                KB_FlushKeyboardQueue();
+                return;
           }
        }
-
+    }
     else
     {
         if( KB_KeyPressed(sc_D) )

--- a/duke3d-go/components/duke3d/Game/menues.c
+++ b/duke3d-go/components/duke3d/Game/menues.c
@@ -48,6 +48,7 @@ extern SDL_Surface *surface;
 extern short inputloc;
 extern int recfilep;
 extern uint8_t  vgacompatible;
+extern uint8_t  actor_tog;   // monster AI toggle: 0=on 1=invisible 2=frozen
 short probey=0,lastprobey=0,last_menu,globalskillsound=-1;
 short sh,onbar,buttonstat,deletespot;
 short last_zero,last_fifty,last_threehundred = 0;
@@ -1842,6 +1843,86 @@ void menus(void)
 
             break;
 
+        // ---------------------------------------------------------------
+        // case 10100 — CHEATS menu
+        // Cheats are always visible but greyed out unless a game is active.
+        // Cheats requiring typed parameters (warp, skill) are not listed here.
+        // ---------------------------------------------------------------
+        case 10100:
+        {
+            // cheat_id == -1 means "warp to vol/level" rather than a cheatquotes[] index.
+            static const struct {
+                int        cheat_id;  // cheatquotes[] index, or -1 for warp
+                int8_t     vol;       // 0-based volume (warp entries only)
+                int8_t     level;     // 0-based level  (warp entries only)
+                const char *label;
+            } cheat_entries[] = {
+                {  0, 0, 0, "GOD MODE"        },  // cornholio
+                { 20, 0, 0, "NO-CLIP"         },  // clip
+                {  1, 0, 0, "ALL STUFF"       },  // stuff
+             // { 17, 0, 0, "SHOW FULL MAP"   },  // showmap — temporarily hidden
+                { 13, 0, 0, "MONSTERS"        },  // monsters
+                { -1, 0, 1, "WARP TO E1L2"   },  // DNSCOTTY102
+                { -1, 0, 2, "WARP TO E1L3"   },  // DNSCOTTY103
+                { -1, 0, 3, "WARP TO E1L4"   },  // DNSCOTTY104
+                { -1, 0, 4, "WARP TO E1L5"   },  // DNSCOTTY105
+                { -1, 0, 5, "WARP TO E1L6"   },  // DNSCOTTY106
+            };
+            #define NUM_CHEAT_ENTRIES ((int)(sizeof(cheat_entries)/sizeof(cheat_entries[0])))
+
+            int ingame = (ps[myconnectindex].gm & MODE_GAME) != 0;
+
+            c = (320>>1)-120;
+            rotatesprite(320<<15,19<<16,65536L,0,MENUBAR,16,0,10,0,0,xdim-1,ydim-1);
+            menutext(320>>1,24,0,0,"CHEATS");
+
+            x = probe(c+6,43,16,NUM_CHEAT_ENTRIES);
+
+            if(x == -1)
+            {
+                cmenu(702);
+                probey = 7;  // keep cursor on CHEATS in GAME OPTIONS
+                break;
+            }
+
+            // Activate selected cheat (only when a game is in progress)
+            if(x >= 0 && ingame)
+            {
+                if(cheat_entries[x].cheat_id == -1)
+                {
+                    // Warp: set volume/level and restart
+                    ud.m_volume_number = ud.volume_number = cheat_entries[x].vol;
+                    ud.m_level_number  = ud.level_number  = cheat_entries[x].level;
+                    ps[myconnectindex].gm |= MODE_RESTART;
+                }
+                else
+                    activate_cheat(cheat_entries[x].cheat_id);
+            }
+
+            // Draw all labels; grey them out when not in-game
+            for(int ci = 0; ci < NUM_CHEAT_ENTRIES; ci++)
+            {
+                int grey = ingame ? 0 : 1;
+                menutext(c, 43+16*ci, 0, grey, (char*)cheat_entries[ci].label);
+            }
+
+            // Show current state for the toggle cheats
+            if(ud.god)        menutext(c+200, 43+16*0, 0, 0, "ON");
+            else              menutext(c+200, 43+16*0, 0, 0, "OFF");
+            // row 1: noclip
+            if(ud.clipping)   menutext(c+200, 43+16*1, 0, 0, "ON");
+            else              menutext(c+200, 43+16*1, 0, 0, "OFF");
+         // row 3: show map — hidden, keep state display commented out too
+         // if(ud.showallmap) menutext(c+200, 43+16*3, 0, 0, "ON");
+         // else              menutext(c+200, 43+16*3, 0, 0, "OFF");
+            // row 3: monsters — 0=ON 1=OFF (invisible)
+            if(actor_tog) menutext(c+200, 43+16*3, 0, 0, "OFF");
+            else          menutext(c+200, 43+16*3, 0, 0, "ON");
+
+            #undef NUM_CHEAT_ENTRIES
+            break;
+        }
+
         case 1000:
         case 1001:
         case 1002:
@@ -2915,13 +2996,13 @@ else
 
             onbar = 0;
 
-			x = probe(c+6,43,16,7);
+		x = probe(c+6,43,16,8);
 
             switch(x)
             {
 
                 case -1:
-					cmenu(200); 
+				cmenu(200); 
                     break;
 
                 case 0:
@@ -2930,31 +3011,34 @@ else
                 case 1:
                     ud.screen_tilting = 1-ud.screen_tilting;
                     break;
-				case 2:
-					ud.showcinematics = !ud.showcinematics;
-					break;
-				case 3:
-					ud.hideweapon = !ud.hideweapon;
-					vscrn(); // FIX_00056: Refresh issue w/FPS, small Weapon and custom FTA, when screen resized down
-					break;
-				case 4:
-					ud.weaponautoswitch = !ud.weaponautoswitch;
-					break;
-				case 5:
-					// FIX_00045: Autoaim mode can now be toggled on/off from menu
-					if( nHostForceDisableAutoaim == 0)
-					{
-						ud.auto_aim++;
-						ud.auto_aim = ((ud.auto_aim-1)%2)+1; // 2 = normal = full; 1 = bullet only
-					}					
-					break;
+			case 2:
+				ud.showcinematics = !ud.showcinematics;
+				break;
+			case 3:
+				ud.hideweapon = !ud.hideweapon;
+				vscrn(); // FIX_00056: Refresh issue w/FPS, small Weapon and custom FTA, when screen resized down
+				break;
+			case 4:
+				ud.weaponautoswitch = !ud.weaponautoswitch;
+				break;
+			case 5:
+				// FIX_00045: Autoaim mode can now be toggled on/off from menu
+				if( nHostForceDisableAutoaim == 0)
+				{
+					ud.auto_aim++;
+					ud.auto_aim = ((ud.auto_aim-1)%2)+1; // 2 = normal = full; 1 = bullet only
+				}					
+				break;
                 case 6: // parental
 #ifndef AUSTRALIA
                     cmenu(10000); 
 #endif
                     break;
+                case 7: // cheats
+                    cmenu(10100);
+                    break;
 
-			}
+		}
 
 
 			menutext(c,43+16*0,SHX(-3),PHX(-3),"SHADOWS");
@@ -2996,9 +3080,9 @@ else
 #else
             menutext(c,43+16*6,SHX(-9),1,"PARENTAL LOCK");
 #endif
+            menutext(c,43+16*7,SHX(-10),PHX(-10),"CHEATS");
 
-
-			break;
+		break;
 
         case 703:
 


### PR DESCRIPTION
This adds the CHEATS to a similar location as in eDuke32.

Buried in the menu's a bit, these cheats are super useful when testing game features, tile and sound completeness, visual tweaks, and level endings without having to play through them every time. The "WARP TO" entries are nice for testing higher levels.

I only added E1L1-6 to avoid having the list becoming to big, and because those are the available levels in the Shareware edition, but more can easily be added if that turns out to be necessary.

How this was done:
- Extract cheat effect logic into activate_cheat(int k) so cheat effects can be triggered without keyboard input. The old DN-prefix keyboard path still works unchanged.
- Add a CHEATS entry as the last item in the Game Options menu (case 702), opening a new submenu (case 10100) with:
    - God Mode, No-Clip, All Stuff, Monsters (ON/OFF toggle)
    - Warp shortcuts for E1L2 through E1L6 (DNSCOTTY102-106)

Cheats are always visible but greyed out when no game is active. Toggle cheats show their current state (ON/OFF) to the right. Monsters cheat cycles between ON and OFF (invisible/no-AI) only.