### PR TITLE
duke3d-go: move missing sound warning from on-screen to console

### DIFF
--- a/duke3d-go/components/duke3d/Game/sounds.c
+++ b/duke3d-go/components/duke3d/Game/sounds.c
@@ -277,10 +277,7 @@ uint8_t  loadsound(uint16_t num)
     fp = TCkopen4load(sounds[num],0);
     if(fp == -1)
     {
-        // console printf is enough; on-screen FTA just annoys the player
         printf("Sound %s(#%d) not found.\n",sounds[num],num);
-        // sprintf(&fta_quotes[113][0],"Sound %s(#%d) not found.",sounds[num],num);
-        // FTA(113,&ps[myconnectindex],1);
         return 0;
     }
 

--- a/duke3d-go/components/duke3d/Game/sounds.c
+++ b/duke3d-go/components/duke3d/Game/sounds.c
@@ -277,8 +277,10 @@ uint8_t  loadsound(uint16_t num)
     fp = TCkopen4load(sounds[num],0);
     if(fp == -1)
     {
-        sprintf(&fta_quotes[113][0],"Sound %s(#%d) not found.",sounds[num],num);
-        FTA(113,&ps[myconnectindex],1);
+        // console printf is enough; on-screen FTA just annoys the player
+        printf("Sound %s(#%d) not found.\n",sounds[num],num);
+        // sprintf(&fta_quotes[113][0],"Sound %s(#%d) not found.",sounds[num],num);
+        // FTA(113,&ps[myconnectindex],1);
         return 0;
     }
 


### PR DESCRIPTION
Don't warn the player on-screen with warnings about missing sound files, as these keep popping up in stripped down builds.

Just warning on the console is enough, as this is more for debugging anyway.